### PR TITLE
Disable `--create` on push by default

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -152,12 +152,12 @@ inputs:
     default: ${{ github.event_name == 'push' }}
   push_create:
     description: |-
-      Create the repository if it does not exist. Must set "push_create_visibility".
+      Create the repository if it does not exist.
     required: false
-    default: "true"
+    default: "false"
   push_create_visibility:
     description: |-
-      Repository's visibility setting if created. Must be set if "push_create" is true.
+      Repository's visibility setting if created.
       Must be either "public" or "private".
     required: false
   push_labels:


### PR DESCRIPTION
Push by default sets the flag `--create` to automatically create the repository if it doesn't exist. This behaviour, however, requires elevated permissions not usually present in CI. In most cases this won't be needed as the modules will already be created. Therefore to cover the common case we now change the default input for `push_create` to false. To maintain the current behaviour explicitly set `push_create: true`.