### PR TITLE
Update buf version 1.32.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ MAKEFLAGS += --no-print-directory
 BIN := .tmp/bin
 COPYRIGHT_YEARS := 2024
 LICENSE_IGNORE := -e dist\/
-BUF_VERSION ?= 1.32.1
+BUF_VERSION ?= 1.32.2
 
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
@@ -47,6 +47,7 @@ endif
 	$(SED_I) "s/version: [0-9]+\.[0-9]+\.[0-9]+/version: $(BUF_VERSION)/g" README.md
 	$(SED_I) "s/buf-action@v[0-9]+\.[0-9]+\.[0-9]+/buf-action@v$(VERSION)/g" README.md
 	$(SED_I) "s/buf-action@v[0-9]+\.[0-9]+\.[0-9]+/buf-action@v$(VERSION)/g" examples/*.yaml
+	$(SED_I) "s/version: [0-9]+\.[0-9]+\.[0-9]+/version: $(BUF_VERSION)/g" examples/*.yaml
 
 .PHONY: generate
 generate: $(BIN)/license-header ## Regenerate licenses

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ To ensure the version of `buf` is consistent across workflows it's recommended t
 ```yaml
 - uses: bufbuild/buf-action@v0.1.0
   with:
-    version: 1.32.1
+    version: 1.32.2
 ```
 
 If no version is specified in the workflow config, the action will resolve the version in order of precendence:
@@ -264,9 +264,9 @@ Here's an example migration from using multiple actions to the new consolidated 
 ```yaml
 steps:
   - uses: actions/checkout@v2
-  - uses: bufbuild/buf-setup-action@v1.31.0
+  - uses: bufbuild/buf-setup-action@v1.32.2
     with:
-      version: 1.32.1
+      version: 1.32.2
       buf_user: ${{ secrets.BUF_USERNAME }}
       buf_api_token: ${{ secrets.BUF_TOKEN }}
   - uses: bufbuild/buf-lint-action@v1
@@ -296,7 +296,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: bufbuild/buf-action@v0.1.0
         with:
-          version: 1.32.1
+          version: 1.32.2
           username: ${{ secrets.BUF_USERNAME }}
           token: ${{ secrets.BUF_TOKEN }}
 ```

--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,7 @@ inputs:
       Version of buf to download and add to the PATH.
       Example:
         with:
-          version: 1.32.1
+          version: 1.32.2
     required: false
   username:
     description: |-
@@ -186,8 +186,7 @@ inputs:
       Whether to run the archive step. Runs by default on deletes.
       Additional labels from the "labels" input are archived.
     required: false
-    #default: ${{ github.event_name == 'delete' }}
-    default: "false" # TODO: enable me when supported.
+    default: ${{ github.event_name == 'delete' }}
   archive_labels:
     description: |-
       Labels to archive (separated by newlines).

--- a/dist/index.js
+++ b/dist/index.js
@@ -37597,8 +37597,7 @@ var semver = __nccwpck_require__(1383);
 
 
 
-// TODO: Set the required version to the the released version.
-const requiredVersion = ">1.31.0";
+const requiredVersion = ">=1.32.0";
 // installBuf installs the buf binary and returns the path to the binary.
 async function installBuf(github, versionInput) {
     let resolvedVersion = resolveVersion(versionInput);

--- a/examples/version-input.yaml
+++ b/examples/version-input.yaml
@@ -12,5 +12,5 @@ jobs:
       - uses: bufbuild/buf-action@v0.1.0
         with:
           setup_only: true
-          version: 1.32.0
+          version: 1.32.2
       - run: buf version

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -20,8 +20,7 @@ import { GitHub } from "@actions/github/lib/utils";
 import * as semver from "semver";
 import { getEnv } from "./inputs";
 
-// TODO: Set the required version to the the released version.
-const requiredVersion = ">1.31.0";
+const requiredVersion = ">=1.32.0";
 
 // installBuf installs the buf binary and returns the path to the binary.
 export async function installBuf(


### PR DESCRIPTION
Runs `VERSION=0.1.0 make updateversion` to update the docs and CI with the latest version of buf `1.32.2`. Removes two TODOS. Fixes an action setting for archive which is safe to enable and sets the min version to `v1.32.0`.