### PR TITLE
Prepare for v0.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: bufbuild/buf-action@v0.1.0
+      - uses: bufbuild/buf-action@v0.1.1
         with:
           username: ${{ secrets.BUF_USERNAME }}
           token: ${{ secrets.BUF_TOKEN }}
@@ -81,7 +81,7 @@ This will install `buf` and optionally login to the schema registry but no addit
 Subsequent steps will have `buf` available in their $PATH and can invoke `buf` directly.
 
 ```yaml
-- uses: bufbuild/buf-action@v0.1.0
+- uses: bufbuild/buf-action@v0.1.1
   with:
     setup_only: true
 - run: buf build --error-format github-actions
@@ -93,7 +93,7 @@ To skip or disable parts of the workflow, each step corresponds to a boolean fla
 For example to disable linting set the input `lint` to `false`:
 
 ```yaml
-- uses: bufbuild/buf-action@v0.1.0
+- uses: bufbuild/buf-action@v0.1.1
   with:
     lint: false
 ```
@@ -106,7 +106,7 @@ To trigger steps on different events use the GitHub action context to deduce the
 For example to enable formatting checks on both pull requests and push create an expression for the input `format`:
 
 ```yaml
-- uses: bufbuild/buf-action@v0.1.0
+- uses: bufbuild/buf-action@v0.1.1
   with:
     format: ${{ contains(fromJSON('["push", "pull_request"]'), github.event_name) }}
 ```
@@ -119,7 +119,7 @@ To conditionally run checks based on user input, use the GitHub action context t
 For example to disable breaking change detection on commits, create an expression on the input `breaking` to check the contents of the commit message:
 
 ```yaml
-- uses: bufbuild/buf-action@v0.1.0
+- uses: bufbuild/buf-action@v0.1.1
   with:
     breaking: |
       contains(fromJSON('["push", "pull_request"]'), github.event_name) &&
@@ -133,7 +133,7 @@ See [GitHub Actions job context](https://docs.github.com/en/actions/reference/co
 To ensure the version of `buf` is consistent across workflows it's recommended to always use an explicit version.
 
 ```yaml
-- uses: bufbuild/buf-action@v0.1.0
+- uses: bufbuild/buf-action@v0.1.1
   with:
     version: 1.32.2
 ```
@@ -154,7 +154,7 @@ The `username` and `token` values can be stored as secrets in the repository set
 The `token` value can be [generated from the Buf Schema Registry UI](https://buf.build/docs/bsr/authentication#create-an-api-token).
 
 ```yaml
-- uses: bufbuild/buf-action@v0.1.0
+- uses: bufbuild/buf-action@v0.1.1
   with:
     username: ${{ secrets.BUF_USERNAME }}
     token: ${{ secrets.BUF_TOKEN }}
@@ -192,7 +192,7 @@ runs-on: ubuntu-latest
 permissions:
   contents: read
 steps:
-  - uses: bufbuild/buf-action@v0.1.0
+  - uses: bufbuild/buf-action@v0.1.1
     with:
       comment: false
 ```
@@ -204,7 +204,7 @@ To run the action for inputs not specified at the root of the repository, set th
 Breaking change detection will also be required to be set to include a `subdir` configured to the same input path.
 
 ```yaml
-- uses: bufbuild/buf-action@v0.1.0
+- uses: bufbuild/buf-action@v0.1.1
   with:
     input: protos
     breaking_against: |
@@ -221,7 +221,7 @@ Alternatively, you may wish to pre-checkout the base branch for breaking changes
   with:
     path: base
     ref: ${{ github.event.pull_request.base.sha }}
-- uses: bufbuild/buf-action@v0.1.0
+- uses: bufbuild/buf-action@v0.1.1
   with:
     input: head/protos
     breaking_against: base/protos
@@ -294,7 +294,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
-      - uses: bufbuild/buf-action@v0.1.0
+      - uses: bufbuild/buf-action@v0.1.1
         with:
           version: 1.32.2
           username: ${{ secrets.BUF_USERNAME }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,37 @@
+# Releasing buf-action
+
+This document outlines how to create a release of buf-action.
+We follow the best practices outlined in the [GitHub Actions documentation][github-release-docs] and [GitHub Actions Toolkit tutorial][github-release-tutorial].
+
+1. Clone the repo, ensuring you have the latest main.
+
+2. On a new branch, run the following commands to update the version of the action:
+
+```bash
+VERSION=X.Y.Z make update-version
+```
+
+3. Open a PR titled "Prepare for vX.Y.Z". Once it's reviewed and CI passes, merge it.
+
+    *Make sure no new commits are merged until the release is complete.*
+
+4. Create a new release using the Github UI:
+    - Under “Choose a tag”, type in “vX.Y.Z” to create a new tag for the release upon publish.
+    - Target the main branch.
+    - Title the Release “vX.Y.Z”.
+    - Click “set as latest release”.
+    - Click "Publish this Action to the GitHub Marketplace".
+
+
+5. Publish the release.
+
+6. Pull down the latest main and move the tags for major (vX) and minor (vX.Y) releases.
+
+```bash
+git tag -fa vX -m "Update vX tag"
+git tag -fa vX.Y -m "Update vX.Y tag"
+git push origin vX vX.Y --force
+```
+
+[github-release-docs]: https://docs.github.com/en/actions/creating-actions/releasing-and-maintaining-actions
+[github-release-tutorial]: https://github.com/actions/toolkit/blob/master/docs/action-versioning.md

--- a/examples/buf-ci.yaml
+++ b/examples/buf-ci.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: bufbuild/buf-action@v0.1.0
+      - uses: bufbuild/buf-action@v0.1.1
         with:
           username: ${{ secrets.BUF_USERNAME }}
           token: ${{ secrets.BUF_TOKEN }}

--- a/examples/only-checks.yaml
+++ b/examples/only-checks.yaml
@@ -12,4 +12,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: bufbuild/buf-action@v0.1.0
+      - uses: bufbuild/buf-action@v0.1.1

--- a/examples/only-setup-defaults.yaml
+++ b/examples/only-setup-defaults.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: bufbuild/buf-action@v0.1.0
+      - uses: bufbuild/buf-action@v0.1.1
         with:
           setup_only: true
       - env:

--- a/examples/only-setup.yaml
+++ b/examples/only-setup.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: bufbuild/buf-action@v0.1.0
+      - uses: bufbuild/buf-action@v0.1.1
         with:
           # Add username or token secrets to your repository settings to
           # authenticate with the Buf Schema Registry.

--- a/examples/only-sync.yaml
+++ b/examples/only-sync.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: bufbuild/buf-action@v0.1.0
+      - uses: bufbuild/buf-action@v0.1.1
         with:
           username: ${{ secrets.BUF_USERNAME }}
           token: ${{ secrets.BUF_TOKEN }}

--- a/examples/push-on-changes.yaml
+++ b/examples/push-on-changes.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: bufbuild/buf-action@v0.1.0
+      - uses: bufbuild/buf-action@v0.1.1
         with:
           username: ${{ secrets.BUF_USERNAME }}
           token: ${{ secrets.BUF_TOKEN }}

--- a/examples/skip-on-commits.yaml
+++ b/examples/skip-on-commits.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: bufbuild/buf-action@v0.1.0
+      - uses: bufbuild/buf-action@v0.1.1
         with:
           username: ${{ secrets.BUF_USERNAME }}
           token: ${{ secrets.BUF_TOKEN }}

--- a/examples/skip-on-labels.yaml
+++ b/examples/skip-on-labels.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: bufbuild/buf-action@v0.1.0
+      - uses: bufbuild/buf-action@v0.1.1
         with:
           username: ${{ secrets.BUF_USERNAME }}
           token: ${{ secrets.BUF_TOKEN }}

--- a/examples/validate-push.yaml
+++ b/examples/validate-push.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: bufbuild/buf-action@v0.1.0
+      - uses: bufbuild/buf-action@v0.1.1
         with:
           # Username and token are required to authenticate with the Buf Schema Registry.
           username: ${{ secrets.BUF_USERNAME }}

--- a/examples/version-env.yaml
+++ b/examples/version-env.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: bufbuild/buf-action@v0.1.0
+      - uses: bufbuild/buf-action@v0.1.1
         with:
           setup_only: true
       - run: buf version

--- a/examples/version-file.yaml
+++ b/examples/version-file.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - run: |
           echo "1.32.0" > .bufversion
-      - uses: bufbuild/buf-action@v0.1.0
+      - uses: bufbuild/buf-action@v0.1.1
         with:
           setup_only: true
       - run: buf version

--- a/examples/version-input.yaml
+++ b/examples/version-input.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: bufbuild/buf-action@v0.1.0
+      - uses: bufbuild/buf-action@v0.1.1
         with:
           setup_only: true
           version: 1.32.2

--- a/examples/version-latest.yaml
+++ b/examples/version-latest.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: bufbuild/buf-action@v0.1.0
+      - uses: bufbuild/buf-action@v0.1.1
         with:
           setup_only: true
       - run: buf version


### PR DESCRIPTION
Add RELEASE.md to document the release workflow. Follows the guide in prep for v0.1.1. 

To publish this release will create the tags `v0` and `v0.1` in addition to the current release `v0.1.1`.