### PR TITLE
Switch to npm binary for license headers

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,17 +18,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-      - uses: actions/setup-go@v5
-        with:
-          go-version: "^1.22"
-          cache: false
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-cache-${{ hashFiles('Makefile') }}
-          restory-keys: ${{ runner.os }}-go-cache-
       - name: Build
         run: |
           make build

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,3 +1,17 @@
+// Copyright 2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import globals from "globals";
 import pluginJs from "@eslint/js";
 import tseslint from "typescript-eslint";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "buf-action",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "buf-action",
-      "version": "1.0.0",
-      "license": "ISC",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "@actions/core": "^1.10.1",
         "@actions/exec": "^1.1.1",
@@ -16,6 +16,7 @@
         "semver": "^7.6.1"
       },
       "devDependencies": {
+        "@bufbuild/license-header": "^0.0.4",
         "@eslint/js": "^9.2.0",
         "@types/node": "^20.12.7",
         "@vercel/ncc": "^0.38.1",
@@ -96,6 +97,18 @@
       "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
       "bin": {
         "uuid": "bin/uuid"
+      }
+    },
+    "node_modules/@bufbuild/license-header": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@bufbuild/license-header/-/license-header-0.0.4.tgz",
+      "integrity": "sha512-wOOrMjfLdDAO/BAKzCs/bvMPz61X3+qYC9nUbYxJYLVPFAlXus8aw2jNktyHEvLToCjOhn5EcpyaCpMzPHyHIQ==",
+      "dev": true,
+      "dependencies": {
+        "picomatch": "^2.3.1"
+      },
+      "bin": {
+        "license-header": "command.mjs"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint --max-warnings 0 src",
     "lint:fix": "eslint --max-warnings 0 --fix src",
     "build": "ncc build -o dist src/main.ts",
-    "generate": "license-header src --ignore 'dist/**'"
+    "generate": "license-header --ignore 'dist/**'"
   },
   "keywords": [
     "actions",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "format": "prettier --write 'src/*.{json,js,jsx,ts,tsx,css}' --log-level error",
     "lint": "eslint --max-warnings 0 src",
     "lint:fix": "eslint --max-warnings 0 --fix src",
-    "build": "ncc build -o dist src/main.ts"
+    "build": "ncc build -o dist src/main.ts",
+    "generate": "license-header src --ignore 'dist/**'"
   },
   "keywords": [
     "actions",
@@ -18,7 +19,13 @@
   ],
   "author": "Buf Technologies, Inc.",
   "license": "Apache-2.0",
+  "licenseHeader": {
+    "licenseType": "apache",
+    "yearRange": "2024",
+    "copyrightHolder": "Buf Technologies, Inc."
+  },
   "devDependencies": {
+    "@bufbuild/license-header": "^0.0.4",
     "@eslint/js": "^9.2.0",
     "@types/node": "^20.12.7",
     "@vercel/ncc": "^0.38.1",


### PR DESCRIPTION
The license-header binary is also available as a npm binary. It integrates nicely into npm projects because it's installed as a npm dependency, supports configuration in package.json, idiomatic glob ignores, and several additional typical file extensions.

Since this is a npm project, it makes sense to me to use it here.
