### PR TITLE
Fix default archive commands for PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -198,4 +198,6 @@ jobs:
           breaking: false
           push: false
           archive: true
+          # On push github.ref_name, on delete github.event.ref_name.
+          archive_labels: ${{ github.ref_name }}
           comment: false

--- a/action.yml
+++ b/action.yml
@@ -186,7 +186,7 @@ inputs:
       Whether to run the archive step. Runs by default on deletes.
       Additional labels from the "labels" input are archived.
     required: false
-    default: ${{ github.event_name == 'delete' }}
+    default: ${{ github.event_name == 'delete' && github.ref_name != github.event.repository.default_branch }}
   archive_labels:
     description: |-
       Labels to archive (separated by newlines).

--- a/action.yml
+++ b/action.yml
@@ -186,7 +186,7 @@ inputs:
       Whether to run the archive step. Runs by default on deletes.
       Additional labels from the "labels" input are archived.
     required: false
-    default: ${{ github.event_name == 'delete' && github.event.ref_name != github.event.repository.default_branch }}
+    default: ${{ github.event_name == 'delete' }}
   archive_labels:
     description: |-
       Labels to archive (separated by newlines).

--- a/action.yml
+++ b/action.yml
@@ -186,7 +186,7 @@ inputs:
       Whether to run the archive step. Runs by default on deletes.
       Additional labels from the "labels" input are archived.
     required: false
-    default: ${{ github.event_name == 'delete' && github.ref_name != github.event.repository.default_branch }}
+    default: ${{ github.event_name == 'delete' && github.event.ref_name != github.event.repository.default_branch }}
   archive_labels:
     description: |-
       Labels to archive (separated by newlines).
@@ -197,7 +197,7 @@ inputs:
             label2
     required: false
     default: |
-      ${{ github.ref_name }}
+      ${{ github.event.ref_name }}
 
 runs:
   using: "node20"


### PR DESCRIPTION
Fix invalid use of `github.ref_name` which points to `main` and not the pull request branch on `delete` events. We now correctly set the label as `github.event.ref_name` which points to the branch.