### PR TITLE
Fix archive for non-existent labels

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -199,3 +199,39 @@ jobs:
           push: false
           archive: true
           comment: false
+  archive_not_exists:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    needs: push
+    steps:
+      - uses: actions/checkout@v4
+      - env:
+          BUF_USERNAME: ${{ secrets.BUF_USERNAME }}
+        run: |
+          mkdir -p proto/foo/v1
+          printf "version: v2\nmodules:\n  - path: proto\n    name: buf.build/${BUF_USERNAME}/foo\n" > buf.yaml
+          printf "syntax = \"proto3\";\npackage foo.v1;\nmessage Bar {}\n" > proto/foo/v1/bar.proto
+      - uses: ./
+        with:
+          username: ${{ secrets.BUF_USERNAME }}
+          token: ${{ secrets.BUF_TOKEN }}
+          lint: false
+          format: false
+          breaking: false
+          push: false
+          archive: true
+          archive_labels: label_does_not_exist
+          comment: false
+      - uses: ./
+        with:
+          username: ${{ secrets.BUF_USERNAME }}
+          token: ${{ secrets.BUF_TOKEN }}
+          lint: false
+          format: false
+          breaking: false
+          push: false
+          archive: true
+          archive_labels: |
+            label_does_not_exist
+            label_does_not_exist_either
+          comment: false

--- a/action.yml
+++ b/action.yml
@@ -196,8 +196,9 @@ inputs:
             label1
             label2
     required: false
+    # See https://docs.github.com/en/rest/using-the-rest-api/github-event-types?apiVersion=2022-11-28#deleteevent
     default: |
-      ${{ github.event.ref_name }}
+      ${{ github.event.ref }}
 
 runs:
   using: "node20"

--- a/dist/index.js
+++ b/dist/index.js
@@ -38006,10 +38006,14 @@ async function archive(bufPath, inputs) {
         core.info("Skipping archive");
         return skip();
     }
+    if (inputs.archive_labels.length == 0) {
+        core.info("Skipping archive, no labels provided");
+        return skip();
+    }
     // Archive is a special case, we want to iterate over all labels to allow
     // for partial failures. If one label fails on not exists, we continue to the
     // next. The last result is returned.
-    let result = skip();
+    let result = pass();
     for (const label of inputs.archive_labels) {
         const args = ["beta", "registry", "archive", "--label", label];
         if (inputs.input) {
@@ -38024,9 +38028,6 @@ async function archive(bufPath, inputs) {
             return latestResult;
         }
         result = latestResult;
-    }
-    if (inputs.archive_labels.length == 0) {
-        core.info("Skipping archive, no labels provided");
     }
     return result;
 }
@@ -38056,6 +38057,9 @@ async function run(bufPath, args) {
 }
 function skip() {
     return { status: Status.Skipped, exitCode: 0, stdout: "", stderr: "" };
+}
+function pass() {
+    return { status: Status.Passed, exitCode: 0, stdout: "", stderr: "" };
 }
 function message(status) {
     switch (status) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -38013,7 +38013,14 @@ async function archive(bufPath, inputs) {
     for (const label of inputs.archive_labels) {
         args.push("--label", label);
     }
-    return run(bufPath, args);
+    const result = await run(bufPath, args);
+    if (result.status == Status.Failed) {
+        if (/Failure: label with name ".*" was not found/.test(result.stderr)) {
+            core.info("Skipping archive, label not found");
+            return skip();
+        }
+    }
+    return result;
 }
 var Status;
 (function (Status) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -279,7 +279,14 @@ async function archive(bufPath: string, inputs: Inputs): Promise<Result> {
   for (const label of inputs.archive_labels) {
     args.push("--label", label);
   }
-  return run(bufPath, args);
+  const result = await run(bufPath, args);
+  if (result.status == Status.Failed) {
+    if (/Failure: label with name ".*" was not found/.test(result.stderr)) {
+      core.info("Skipping archive, label not found");
+      return skip();
+    }
+  }
+  return result;
 }
 
 enum Status {

--- a/src/main.ts
+++ b/src/main.ts
@@ -272,10 +272,14 @@ async function archive(bufPath: string, inputs: Inputs): Promise<Result> {
     core.info("Skipping archive");
     return skip();
   }
+  if (inputs.archive_labels.length == 0) {
+    core.info("Skipping archive, no labels provided");
+    return skip();
+  }
   // Archive is a special case, we want to iterate over all labels to allow
   // for partial failures. If one label fails on not exists, we continue to the
   // next. The last result is returned.
-  let result = skip();
+  let result = pass();
   for (const label of inputs.archive_labels) {
     const args = ["beta", "registry", "archive", "--label", label];
     if (inputs.input) {
@@ -292,9 +296,6 @@ async function archive(bufPath: string, inputs: Inputs): Promise<Result> {
       return latestResult;
     }
     result = latestResult;
-  }
-  if (inputs.archive_labels.length == 0) {
-    core.info("Skipping archive, no labels provided");
   }
   return result;
 }
@@ -333,6 +334,9 @@ async function run(bufPath: string, args: string[]): Promise<Result> {
 
 function skip(): Result {
   return { status: Status.Skipped, exitCode: 0, stdout: "", stderr: "" };
+}
+function pass(): Result {
+  return { status: Status.Passed, exitCode: 0, stdout: "", stderr: "" };
 }
 
 function message(status: Status | undefined): string {

--- a/src/main.ts
+++ b/src/main.ts
@@ -272,19 +272,29 @@ async function archive(bufPath: string, inputs: Inputs): Promise<Result> {
     core.info("Skipping archive");
     return skip();
   }
-  const args = ["beta", "registry", "archive"];
-  if (inputs.input) {
-    args.push(inputs.input);
-  }
+  // Archive is a special case, we want to iterate over all labels to allow
+  // for partial failures. If one label fails on not exists, we continue to the
+  // next. The last result is returned.
+  let result = skip();
   for (const label of inputs.archive_labels) {
-    args.push("--label", label);
-  }
-  const result = await run(bufPath, args);
-  if (result.status == Status.Failed) {
-    if (/Failure: label with name ".*" was not found/.test(result.stderr)) {
-      core.info("Skipping archive, label not found");
-      return skip();
+    const args = ["beta", "registry", "archive", "--label", label];
+    if (inputs.input) {
+      args.push(inputs.input);
     }
+    const latestResult = await run(bufPath, args);
+    if (latestResult.status == Status.Failed) {
+      if (
+        /Failure: label with name ".*" was not found/.test(latestResult.stderr)
+      ) {
+        core.info(`Skipping archive, label ${label} not found`);
+        continue;
+      }
+      return latestResult;
+    }
+    result = latestResult;
+  }
+  if (inputs.archive_labels.length == 0) {
+    core.info("Skipping archive, no labels provided");
   }
   return result;
 }


### PR DESCRIPTION
This PR fixes two issues with the archive step. First is a typo in the default event name of `archive_labels`. This should be `github.event.ref` not `github.event.ref_name. The other fix is for more robust handling of multiple non existent labels. For `delete` events we cannot guarantee the branch or tag is matched to a label in the BSR. We now iterate over all labels and handle missing failures.