### PR TITLE
Prepare for v0.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: bufbuild/buf-action@v0.1.1
+      - uses: bufbuild/buf-action@v0.1.2
         with:
           username: ${{ secrets.BUF_USERNAME }}
           token: ${{ secrets.BUF_TOKEN }}
@@ -81,7 +81,7 @@ This will install `buf` and optionally login to the schema registry but no addit
 Subsequent steps will have `buf` available in their $PATH and can invoke `buf` directly.
 
 ```yaml
-- uses: bufbuild/buf-action@v0.1.1
+- uses: bufbuild/buf-action@v0.1.2
   with:
     setup_only: true
 - run: buf build --error-format github-actions
@@ -93,7 +93,7 @@ To skip or disable parts of the workflow, each step corresponds to a boolean fla
 For example to disable linting set the input `lint` to `false`:
 
 ```yaml
-- uses: bufbuild/buf-action@v0.1.1
+- uses: bufbuild/buf-action@v0.1.2
   with:
     lint: false
 ```
@@ -106,7 +106,7 @@ To trigger steps on different events use the GitHub action context to deduce the
 For example to enable formatting checks on both pull requests and push create an expression for the input `format`:
 
 ```yaml
-- uses: bufbuild/buf-action@v0.1.1
+- uses: bufbuild/buf-action@v0.1.2
   with:
     format: ${{ contains(fromJSON('["push", "pull_request"]'), github.event_name) }}
 ```
@@ -119,7 +119,7 @@ To conditionally run checks based on user input, use the GitHub action context t
 For example to disable breaking change detection on commits, create an expression on the input `breaking` to check the contents of the commit message:
 
 ```yaml
-- uses: bufbuild/buf-action@v0.1.1
+- uses: bufbuild/buf-action@v0.1.2
   with:
     breaking: |
       contains(fromJSON('["push", "pull_request"]'), github.event_name) &&
@@ -133,7 +133,7 @@ See [GitHub Actions job context](https://docs.github.com/en/actions/reference/co
 To ensure the version of `buf` is consistent across workflows it's recommended to always use an explicit version.
 
 ```yaml
-- uses: bufbuild/buf-action@v0.1.1
+- uses: bufbuild/buf-action@v0.1.2
   with:
     version: 1.32.2
 ```
@@ -153,7 +153,7 @@ The `username` and `token` values can be stored as secrets in the repository set
 The `token` value can be [generated from the Buf Schema Registry UI](https://buf.build/docs/bsr/authentication#create-an-api-token).
 
 ```yaml
-- uses: bufbuild/buf-action@v0.1.1
+- uses: bufbuild/buf-action@v0.1.2
   with:
     username: ${{ secrets.BUF_USERNAME }}
     token: ${{ secrets.BUF_TOKEN }}
@@ -191,7 +191,7 @@ runs-on: ubuntu-latest
 permissions:
   contents: read
 steps:
-  - uses: bufbuild/buf-action@v0.1.1
+  - uses: bufbuild/buf-action@v0.1.2
     with:
       comment: false
 ```
@@ -203,7 +203,7 @@ To run the action for inputs not specified at the root of the repository, set th
 Breaking change detection will also be required to be set to include a `subdir` configured to the same input path.
 
 ```yaml
-- uses: bufbuild/buf-action@v0.1.1
+- uses: bufbuild/buf-action@v0.1.2
   with:
     input: protos
     breaking_against: |
@@ -220,7 +220,7 @@ Alternatively, you may wish to pre-checkout the base branch for breaking changes
   with:
     path: base
     ref: ${{ github.event.pull_request.base.sha }}
-- uses: bufbuild/buf-action@v0.1.1
+- uses: bufbuild/buf-action@v0.1.2
   with:
     input: head/protos
     breaking_against: base/protos
@@ -293,7 +293,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
-      - uses: bufbuild/buf-action@v0.1.1
+      - uses: bufbuild/buf-action@v0.1.2
         with:
           version: 1.32.2
           username: ${{ secrets.BUF_USERNAME }}

--- a/examples/buf-ci.yaml
+++ b/examples/buf-ci.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: bufbuild/buf-action@v0.1.1
+      - uses: bufbuild/buf-action@v0.1.2
         with:
           username: ${{ secrets.BUF_USERNAME }}
           token: ${{ secrets.BUF_TOKEN }}

--- a/examples/only-checks.yaml
+++ b/examples/only-checks.yaml
@@ -11,4 +11,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: bufbuild/buf-action@v0.1.1
+      - uses: bufbuild/buf-action@v0.1.2

--- a/examples/only-setup-defaults.yaml
+++ b/examples/only-setup-defaults.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: bufbuild/buf-action@v0.1.1
+      - uses: bufbuild/buf-action@v0.1.2
         with:
           setup_only: true
       - env:

--- a/examples/only-setup.yaml
+++ b/examples/only-setup.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: bufbuild/buf-action@v0.1.1
+      - uses: bufbuild/buf-action@v0.1.2
         with:
           # Add username or token secrets to your repository settings to
           # authenticate with the Buf Schema Registry.

--- a/examples/only-sync.yaml
+++ b/examples/only-sync.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: bufbuild/buf-action@v0.1.1
+      - uses: bufbuild/buf-action@v0.1.2
         with:
           username: ${{ secrets.BUF_USERNAME }}
           token: ${{ secrets.BUF_TOKEN }}

--- a/examples/push-on-changes.yaml
+++ b/examples/push-on-changes.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: bufbuild/buf-action@v0.1.1
+      - uses: bufbuild/buf-action@v0.1.2
         with:
           username: ${{ secrets.BUF_USERNAME }}
           token: ${{ secrets.BUF_TOKEN }}

--- a/examples/skip-on-commits.yaml
+++ b/examples/skip-on-commits.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: bufbuild/buf-action@v0.1.1
+      - uses: bufbuild/buf-action@v0.1.2
         with:
           username: ${{ secrets.BUF_USERNAME }}
           token: ${{ secrets.BUF_TOKEN }}

--- a/examples/skip-on-labels.yaml
+++ b/examples/skip-on-labels.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: bufbuild/buf-action@v0.1.1
+      - uses: bufbuild/buf-action@v0.1.2
         with:
           username: ${{ secrets.BUF_USERNAME }}
           token: ${{ secrets.BUF_TOKEN }}

--- a/examples/validate-push.yaml
+++ b/examples/validate-push.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: bufbuild/buf-action@v0.1.1
+      - uses: bufbuild/buf-action@v0.1.2
         with:
           # Username and token are required to authenticate with the Buf Schema Registry.
           username: ${{ secrets.BUF_USERNAME }}

--- a/examples/version-env.yaml
+++ b/examples/version-env.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: bufbuild/buf-action@v0.1.1
+      - uses: bufbuild/buf-action@v0.1.2
         with:
           setup_only: true
       - run: buf version

--- a/examples/version-input.yaml
+++ b/examples/version-input.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: bufbuild/buf-action@v0.1.1
+      - uses: bufbuild/buf-action@v0.1.2
         with:
           setup_only: true
           version: 1.32.2

--- a/examples/version-latest.yaml
+++ b/examples/version-latest.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: bufbuild/buf-action@v0.1.1
+      - uses: bufbuild/buf-action@v0.1.2
         with:
           setup_only: true
       - run: buf version


### PR DESCRIPTION
Whats changed:
- Fix default archive label in #10 
- Drop support for `.bufversion` files in #8 

Removed support for `.bufversion` files is a breaking change but is not currently used by known implementations.