### PR TITLE
Add example to disable label skips

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ by adding a label with a (case-insensitive) special name to that PR.
 - `buf skip format`: skips format. 
 
 Ensure the workflow file includes the `pull_request` event types `labeled` and `unlabeled` so checks re-run on label changes.
+To disable this behaviour, override the action inputs `breaking`, `lint`, and `format`.
+See [examples/disable-skip/buf-ci.yaml](examples/disable-skip/buf-ci.yaml) for an example.
 
 ### Versioning
 

--- a/examples/disable-skip/buf-ci.yaml
+++ b/examples/disable-skip/buf-ci.yaml
@@ -1,0 +1,24 @@
+# This workflow disables the use of labels for skipping checks. It does this by
+# removing the expressions that check for the presence of the 'buf skip' labels.
+# As a result, the pull_request types for labeled and unlabeled events can now
+# also be removed (NB: the 'pull_request' default event types include opened,
+# synchronize, and reopened).
+name: Buf CI
+on:
+  push:
+  pull_request:
+  delete:
+permissions:
+  contents: read
+jobs:
+  buf:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: bufbuild/buf-action@v0.1.3
+        with:
+          username: ${{ secrets.BUF_USERNAME }}
+          token: ${{ secrets.BUF_TOKEN }}
+          lint: ${{ github.event_name == 'pull_request' }}
+          format: ${{ github.event_name == 'pull_request' }}
+          breaking: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
This PR showcases a workflow to disable label skips which are on by default. To disable, we override the default input removing the checks against the label.