### PR TITLE
Require buf v1.34.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ permissions:
   contents: read
   pull-requests: write
 env:
-  BUF_VERSION: "1.33.0"
+  BUF_VERSION: "1.34.0"
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ SHELL := bash
 MAKEFLAGS += --warn-undefined-variables
 MAKEFLAGS += --no-builtin-rules
 MAKEFLAGS += --no-print-directory
-BUF_VERSION ?= 1.33.0
+BUF_VERSION ?= 1.34.0
 
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ For reproducible builds, you can pin to an explicit version of `buf` by setting 
 ```yaml
 - uses: bufbuild/buf-action@v0.1
   with:
-    version: 1.33.0
+    version: 1.34.0
 ```
 
 If no version is specified in the workflow config, the action will resolve the version in order of precendence:

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ inputs:
       Version of the Buf CLI to use.
       Example:
         with:
-          version: 1.33.0
+          version: 1.34.0
     required: false
   username:
     description: |-

--- a/dist/index.js
+++ b/dist/index.js
@@ -53930,7 +53930,7 @@ var tool_cache = __nccwpck_require__(7784);
 
 
 // requiredVersion is the minimum version of buf required.
-const requiredVersion = ">=1.32.0";
+const requiredVersion = ">=1.34.0";
 // installBuf installs the buf binary and returns the path to the binary. The
 // versionInput should be an explicit version of buf.
 async function installBuf(github, versionInput) {

--- a/examples/version-input/buf-ci.yaml
+++ b/examples/version-input/buf-ci.yaml
@@ -12,5 +12,5 @@ jobs:
       - uses: bufbuild/buf-action@v0.1
         with:
           setup_only: true
-          version: 1.33.0
+          version: 1.34.0
       - run: buf version

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -20,7 +20,7 @@ import * as semver from "semver";
 import { getEnv } from "./inputs";
 
 // requiredVersion is the minimum version of buf required.
-const requiredVersion = ">=1.32.0";
+const requiredVersion = ">=1.34.0";
 
 // installBuf installs the buf binary and returns the path to the binary. The
 // versionInput should be an explicit version of buf.


### PR DESCRIPTION
Set the min supported version of buf to v1.34.0. This pulls in the required change https://github.com/bufbuild/buf/pull/3103 for better compatibility with different environments.