### PR TITLE
Skip when dependabot[bot] actor

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -45385,6 +45385,8 @@ function getInputs() {
         domain: core.getInput("domain"),
         setup_only: core.getBooleanInput("setup_only"),
         pr_comment: core.getBooleanInput("pr_comment"),
+        github_actor: core.getInput("github_actor"),
+        github_token: core.getInput("github_token"),
         // Inputs shared between buf steps.
         input: core.getInput("input"),
         paths: core.getMultilineInput("paths"),
@@ -45717,9 +45719,13 @@ function parseModuleName(moduleName) {
 // main is the entrypoint for the action.
 async function main() {
     const inputs = getInputs();
-    const github = (0,lib_github.getOctokit)(core.getInput("github_token"));
+    const github = (0,lib_github.getOctokit)(inputs.github_token);
     const [bufPath, bufVersion] = await installBuf(github, inputs.version);
     core.setOutput(Outputs.BufVersion, bufVersion);
+    if (inputs.github_actor == "dependabot[bot]") {
+        core.info("Skipping steps for dependabot");
+        return;
+    }
     await login(bufPath, inputs);
     if (inputs.setup_only) {
         core.info("Setup only, skipping steps");

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -28,6 +28,8 @@ export interface Inputs {
   domain: string;
   setup_only: boolean;
   pr_comment: boolean;
+  github_actor: string;
+  github_token: string;
 
   input: string;
   paths: string[];
@@ -53,6 +55,8 @@ export function getInputs(): Inputs {
     domain: core.getInput("domain"),
     setup_only: core.getBooleanInput("setup_only"),
     pr_comment: core.getBooleanInput("pr_comment"),
+    github_actor: core.getInput("github_actor"),
+    github_token: core.getInput("github_token"),
     // Inputs shared between buf steps.
     input: core.getInput("input"),
     paths: core.getMultilineInput("paths"),

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,11 +30,14 @@ import { parseModuleNames, ModuleName } from "./config";
 // main is the entrypoint for the action.
 async function main() {
   const inputs = getInputs();
-  const github = getOctokit(core.getInput("github_token"));
+  const github = getOctokit(inputs.github_token);
   const [bufPath, bufVersion] = await installBuf(github, inputs.version);
   core.setOutput(Outputs.BufVersion, bufVersion);
+  if (inputs.github_actor == "dependabot[bot]") {
+    core.info("Skipping steps for dependabot");
+    return;
+  }
   await login(bufPath, inputs);
-
   if (inputs.setup_only) {
     core.info("Setup only, skipping steps");
     return;


### PR DESCRIPTION
Dependabot doesn't have access to repository secrets failing to run workflows when automatically run. We can easily check in the action for the actor [`dependabot[bot]`](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#responding-to-events) to skip these cases. This avoids users having to configure the action themselves.