### PR TITLE
Update workflow for dependabot exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ permissions:
 jobs:
   buf:
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v4
       - uses: bufbuild/buf-action@v0.2
@@ -164,6 +165,7 @@ permissions:
 jobs:
   buf:
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v4
       - uses: bufbuild/buf-action@v0.2

--- a/examples/buf-ci.yaml
+++ b/examples/buf-ci.yaml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   buf:
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v4
       - uses: bufbuild/buf-action@v0.2

--- a/examples/disable-skip/buf-ci.yaml
+++ b/examples/disable-skip/buf-ci.yaml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   buf:
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v4
       - uses: bufbuild/buf-action@v0.2

--- a/examples/only-checks/buf-ci.yaml
+++ b/examples/only-checks/buf-ci.yaml
@@ -9,6 +9,7 @@ permissions:
 jobs:
   buf:      
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v4
       - uses: bufbuild/buf-action@v0.2

--- a/examples/only-setup/buf-ci.yaml
+++ b/examples/only-setup/buf-ci.yaml
@@ -8,6 +8,7 @@ permissions:
 jobs:
   buf:      
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v4
       - uses: bufbuild/buf-action@v0.2

--- a/examples/push-on-changes/buf-ci.yaml
+++ b/examples/push-on-changes/buf-ci.yaml
@@ -17,6 +17,7 @@ permissions:
 jobs:
   buf:
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v4
       - uses: bufbuild/buf-action@v0.2

--- a/examples/skip-on-commits/buf-ci.yaml
+++ b/examples/skip-on-commits/buf-ci.yaml
@@ -8,6 +8,7 @@ permissions:
 jobs:
   buf:      
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v4
       - uses: bufbuild/buf-action@v0.2

--- a/examples/skip-on-labels/buf-ci.yaml
+++ b/examples/skip-on-labels/buf-ci.yaml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   buf:      
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v4
       - uses: bufbuild/buf-action@v0.2

--- a/examples/validate-push/buf-ci.yaml
+++ b/examples/validate-push/buf-ci.yaml
@@ -8,6 +8,7 @@ permissions:
 jobs:
   buf:      
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v4
       - uses: bufbuild/buf-action@v0.2

--- a/examples/version-env/buf-ci.yaml
+++ b/examples/version-env/buf-ci.yaml
@@ -9,6 +9,7 @@ env:
 jobs:
   buf:      
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v4
       - uses: bufbuild/buf-action@v0.2

--- a/examples/version-input/buf-ci.yaml
+++ b/examples/version-input/buf-ci.yaml
@@ -7,6 +7,7 @@ permissions:
 jobs:
   buf:      
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v4
       - uses: bufbuild/buf-action@v0.2

--- a/examples/version-latest/buf-ci.yaml
+++ b/examples/version-latest/buf-ci.yaml
@@ -7,6 +7,7 @@ permissions:
 jobs:
   buf:      
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v4
       - uses: bufbuild/buf-action@v0.2


### PR DESCRIPTION
This is an alternative to #44 where we instead of special casing the `dependabot[bot]` actor we can update each workflow with the new recommendation.
