### PR TITLE
Improve summary comments

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -160,6 +160,7 @@ jobs:
           archive: false
           pr_comment: true
       - uses: actions/github-script@v7
+        if: false
         with:
           script: |
             const expectedComment = `The latest Buf updates on your PR.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -160,13 +160,14 @@ jobs:
           archive: false
           pr_comment: true
       - uses: actions/github-script@v7
-        if: false
         with:
           script: |
-            const expectedComment = `The latest Buf updates on your PR.
-
-            <table><tr><th>Name</th><th>Status</th></tr><tr><td>build</td><td>✅ passed</td></tr><tr><td>lint</td><td>⏩ skipped</td></tr><tr><td>format</td><td>❌ failed</td></tr><tr><td>breaking</td><td>✅ passed</td></tr></table>
-            <!-- Buf results -->`
+            const expects = [
+              "The latest Buf updates on your PR.",
+              "✅ passed",
+              "❌ failed (1)",
+              "⏩ skipped",
+            ];
             const commentTag = "<!-- Buf results -->";
             const { owner, repo } = context.repo;
             const prNumber = context.payload.pull_request?.number;
@@ -186,11 +187,11 @@ jobs:
               core.setFailed('Missing comment on pull request.');
               return;
             }
-            if (!previousComment.body?.includes(expectedComment)) {
-              core.setFailed('Comment does not match expected.');
-              core.info(`Expected: ${expectedComment}`);
-              core.info(`Comment: ${previousComment.body}`);
-              return;
+            for (const line of expects) {
+              if (!previousComment.body?.includes(line)) {
+                core.setFailed(`Comment does not include expected line: ${line}`);
+                return;
+              }
             }
             await github.rest.issues.updateComment({
               owner: owner,

--- a/dist/index.js
+++ b/dist/index.js
@@ -45814,7 +45814,8 @@ function createSummary(inputs, steps) {
             message(steps.format?.status),
             message(steps.breaking?.status),
             message(steps.lint?.status),
-            `<a href={"${lib_github.context.serverUrl}/${lib_github.context.repo.owner}/${lib_github.context.repo.repo}/actions/runs/${lib_github.context.runId}">${lib_github.context.runId}</a>`,
+            `[${lib_github.context.serverUrl}/${lib_github.context.repo.owner}/${lib_github.context.repo.repo}/actions/runs/${lib_github.context.runId}](${lib_github.context.serverUrl}/${lib_github.context.repo.owner}/${lib_github.context.repo.repo}/actions/runs/${lib_github.context.runId})
+${lib_github.context.serverUrl}/${lib_github.context.repo.owner}/${lib_github.context.repo.repo}/actions/runs/${lib_github.context.runId}`,
             new Date().toISOString(),
         ],
     ];

--- a/dist/index.js
+++ b/dist/index.js
@@ -45939,7 +45939,7 @@ async function format(bufPath, inputs) {
         args.push("--exclude-path", path);
     }
     const result = await run(bufPath, args);
-    if (result.status == Status.Failed) {
+    if (result.status == Status.Failed && result.stdout.startsWith("diff")) {
         // If the format step fails, parse the diff and write github annotations.
         const diff = parse_diff(result.stdout);
         result.stdout = ""; // Clear the stdout.
@@ -45947,6 +45947,7 @@ async function format(bufPath, inputs) {
         for (const file of diff) {
             result.stdout += `::error file=${file.to}::Format failed -${file.deletions} +${file.additions} changes.\n`;
         }
+        console.log(result.stdout);
     }
     return result;
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -46080,7 +46080,7 @@ function message(result) {
         case Status.Passed:
             return "✅ passed";
         case Status.Failed:
-            return `❌ failed (${result.stdout.split("\n").length})`;
+            return `❌ failed (${result.stdout.split("\n").length - 1})`;
         case Status.Skipped:
             return "⏩ skipped";
         default:

--- a/dist/index.js
+++ b/dist/index.js
@@ -45839,14 +45839,14 @@ function createSummary(inputs, steps, moduleNames) {
     // If push or archive is enabled add a link to the registry.
     //if (inputs.push) table.push(["push", message(steps.push?.status)]);
     //if (inputs.archive) table.push(["archive", message(steps.archive?.status)]);
-    const output = core.summary.addTable(table);
+    let output = core.summary.addTable(table);
     if (inputs.push && moduleNames.length > 0) {
         const modules = moduleNames.map((moduleName) => `<a href="https://${moduleName.name}">${moduleName.name}</a>`);
-        output.addRaw(`Pushed ${modules.join(", ")} to registry.`, true);
+        output = output.addRaw(`Pushed ${modules.join(", ")} to registry.`, true);
     }
     if (inputs.archive && moduleNames.length > 0) {
         const modules = moduleNames.map((moduleName) => `<a href="https://${moduleName.name}">${moduleName.name}</a>`);
-        output.addRaw(`Archived ${modules.join(", ")} with ${inputs.archive_labels.join(", ")} labels.`, true);
+        output = output.addRaw(`Archived ${modules.join(", ")} with ${inputs.archive_labels.join(", ")} labels.`, true);
     }
     return output;
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -45945,13 +45945,7 @@ async function format(bufPath, inputs) {
         result.stdout = ""; // Clear the stdout.
         console.log("diff", diff);
         for (const file of diff) {
-            for (const chunk of file.chunks) {
-                for (const change of chunk.changes) {
-                    // TODO: Write annotations.
-                    console.log("change", change);
-                    //result.stdout += `::error file=${name},line=${line},title=${title}::${message}\n`;
-                }
-            }
+            result.stdout += `::error file=${file.to}::Format failed -${file.deletions} +${file.additions} changes.\n`;
         }
     }
     return result;

--- a/dist/index.js
+++ b/dist/index.js
@@ -45814,7 +45814,7 @@ function createSummary(inputs, steps) {
             message(steps.format),
             message(steps.breaking),
             message(steps.lint),
-            `<a href="${lib_github.context.serverUrl}/${lib_github.context.repo.owner}/${lib_github.context.repo.repo}/actions/runs/${lib_github.context.runId}">View</a>`,
+            `<a href="${lib_github.context.serverUrl}/${lib_github.context.repo.owner}/${lib_github.context.repo.repo}/actions/runs/${lib_github.context.runId}">view</a>`,
             new Date().toLocaleString("en-US", {
                 timeZone: "UTC",
                 hour12: true,
@@ -46080,7 +46080,7 @@ function message(result) {
         case Status.Passed:
             return "✅ passed";
         case Status.Failed:
-            return `❌ failed (${result.stderr.split("\n").length})`;
+            return `❌ failed (${result.stdout.split("\n").length})`;
         case Status.Skipped:
             return "⏩ skipped";
         default:

--- a/dist/index.js
+++ b/dist/index.js
@@ -45807,16 +45807,13 @@ function createSummary(inputs, steps) {
             { data: "Breaking", header: true },
             { data: "Lint", header: true },
             { data: "Job", header: true },
-            { data: "Commit", header: true },
-            { data: "Updated (UTC)", header: true },
         ],
         [
-            message(steps.build?.status),
-            message(steps.format?.status),
-            message(steps.breaking?.status),
-            message(steps.lint?.status),
+            message(steps.build),
+            message(steps.format),
+            message(steps.breaking),
+            message(steps.lint),
             `<a href="${lib_github.context.serverUrl}/${lib_github.context.repo.owner}/${lib_github.context.repo.repo}/actions/runs/${lib_github.context.runId}/job/${lib_github.context.job}">View</a>`,
-            new Date().toISOString(),
         ],
     ];
     // If push or archive is enabled add a link to the registry.
@@ -46074,12 +46071,12 @@ function pass() {
 }
 // message returns a human-readable message for the status. An undefined status
 // is considered cancelled.
-function message(status) {
-    switch (status) {
+function message(result) {
+    switch (result?.status) {
         case Status.Passed:
             return "✅ passed";
         case Status.Failed:
-            return "❌ failed";
+            return `❌ failed (${result.stderr.split("\n").length})`;
         case Status.Skipped:
             return "⏩ skipped";
         default:

--- a/dist/index.js
+++ b/dist/index.js
@@ -45610,8 +45610,7 @@ async function downloadBuf(version) {
 const commentTag = "<!-- Buf results -->";
 // findCommentOnPR finds the comment on the PR that contains the Buf results.
 // If the comment is found, it returns the comment ID. If the comment is not
-// found, it returns undefined. On failure, it returns undefined but does not
-// throw an error.
+// found, it returns undefined.
 async function findCommentOnPR(context, github) {
     const { owner, repo } = context.repo;
     const prNumber = context.payload.pull_request?.number;
@@ -45633,8 +45632,7 @@ async function findCommentOnPR(context, github) {
 }
 // commentOnPR comments on the PR with the summary of the Buf results. The
 // summary should be a markdown formatted string. This function returns true if
-// the comment was successfully created or updated. On failure, it returns
-// false but does not throw an error.
+// the comment was successfully created or updated.
 async function commentOnPR(context, github, commentID, body) {
     const { owner, repo } = context.repo;
     const prNumber = context.payload.pull_request?.number;

--- a/dist/index.js
+++ b/dist/index.js
@@ -45839,7 +45839,16 @@ function createSummary(inputs, steps, moduleNames) {
     // If push or archive is enabled add a link to the registry.
     //if (inputs.push) table.push(["push", message(steps.push?.status)]);
     //if (inputs.archive) table.push(["archive", message(steps.archive?.status)]);
-    return core.summary.addTable(table);
+    const output = core.summary.addTable(table);
+    if (inputs.push && moduleNames.length > 0) {
+        const modules = moduleNames.map((moduleName) => `<a href="https://${moduleName.name}">${moduleName.name}</a>`);
+        output.addRaw(`Pushed ${modules.join(", ")} to registry.`, true);
+    }
+    if (inputs.archive && moduleNames.length > 0) {
+        const modules = moduleNames.map((moduleName) => `<a href="https://${moduleName.name}">${moduleName.name}</a>`);
+        output.addRaw(`Archived ${modules.join(", ")} with ${inputs.archive_labels.join(", ")} labels.`, true);
+    }
+    return output;
 }
 // runWorkflow runs the buf workflow. It returns the results of each step.
 // First, it builds the input. If the build fails, the workflow stops.
@@ -45944,7 +45953,7 @@ async function format(bufPath, inputs) {
         const diff = parse_diff(result.stdout);
         result.stdout = ""; // Clear the stdout to count the number of changes.
         for (const file of diff) {
-            result.stdout += `::error file=${file.to},title=Buf format::Diff -${file.deletions}/+${file.additions}.\n`;
+            result.stdout += `::error file=${file.to}::Format diff -${file.deletions}/+${file.additions}.\n`;
         }
         console.log(result.stdout);
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -45752,7 +45752,10 @@ async function main() {
     // Comment on the PR with the summary, if requested.
     if (inputs.pr_comment) {
         const commentID = await findCommentOnPR(lib_github.context, github);
-        await commentOnPR(lib_github.context, github, commentID, `The latest Buf updates on your PR.\n\n${summary.stringify()}`);
+        await commentOnPR(lib_github.context, github, commentID, `The latest Buf updates on your PR. ${linkToRun("View")} the run, last updated ${new Date().toLocaleString("en-US", {
+            timeZone: "UTC",
+            hour12: true,
+        })}.\n\n${summary.stringify()}`);
     }
     // Write the summary to a file defined by GITHUB_STEP_SUMMARY.
     // NB: Write empties the buffer and must be after the comment.
@@ -45772,24 +45775,13 @@ main()
 function createSummary(inputs, steps, moduleNames) {
     const table = [
         [
-            { data: "Build", header: true },
-            { data: "Format", header: true },
-            { data: "Lint", header: true },
-            { data: "Breaking", header: true },
-            { data: "Run", header: true },
-            { data: "Updated (UTC)", header: true },
+            { data: "Name", header: true },
+            { data: "Status", header: true },
         ],
-        [
-            message(steps.build),
-            message(steps.format),
-            message(steps.lint),
-            message(steps.breaking),
-            `<a href="${lib_github.context.serverUrl}/${lib_github.context.repo.owner}/${lib_github.context.repo.repo}/actions/runs/${lib_github.context.runId}">view</a>`,
-            new Date().toLocaleString("en-US", {
-                timeZone: "UTC",
-                hour12: true,
-            }),
-        ],
+        ["build", message(steps.build)],
+        ["lint", message(steps.lint)],
+        ["format", message(steps.format)],
+        ["breaking", message(steps.breaking)],
     ];
     // If push or archive is enabled add a link to the registry.
     let output = core.summary.addTable(table);
@@ -46072,6 +46064,9 @@ function message(result) {
         default:
             return "<code>🚫 cancelled</code>";
     }
+}
+function linkToRun(message) {
+    return `<a href="${lib_github.context.serverUrl}/${lib_github.context.repo.owner}/${lib_github.context.repo.repo}/actions/runs/${lib_github.context.runId}">${message}</a>`;
 }
 
 })();

--- a/dist/index.js
+++ b/dist/index.js
@@ -45806,7 +45806,8 @@ function createSummary(inputs, steps) {
             { data: "Format", header: true },
             { data: "Breaking", header: true },
             { data: "Lint", header: true },
-            { data: "Run", header: true },
+            { data: "Job", header: true },
+            { data: "Commit", header: true },
             { data: "Updated (UTC)", header: true },
         ],
         [
@@ -45814,7 +45815,7 @@ function createSummary(inputs, steps) {
             message(steps.format?.status),
             message(steps.breaking?.status),
             message(steps.lint?.status),
-            `<a href="${lib_github.context.serverUrl}/${lib_github.context.repo.owner}/${lib_github.context.repo.repo}/actions/runs/${lib_github.context.runId}">View</a>`,
+            `<a href="${lib_github.context.serverUrl}/${lib_github.context.repo.owner}/${lib_github.context.repo.repo}/actions/runs/${lib_github.context.runId}/job/${lib_github.context.job}">View</a>`,
             new Date().toISOString(),
         ],
     ];

--- a/dist/index.js
+++ b/dist/index.js
@@ -45752,10 +45752,7 @@ async function main() {
     // Comment on the PR with the summary, if requested.
     if (inputs.pr_comment) {
         const commentID = await findCommentOnPR(lib_github.context, github);
-        await commentOnPR(lib_github.context, github, commentID, `The latest Buf updates on your PR. ${linkToRun("View")} the run, last updated ${new Date().toLocaleString("en-US", {
-            timeZone: "UTC",
-            hour12: true,
-        })}.\n\n${summary.stringify()}`);
+        await commentOnPR(lib_github.context, github, commentID, `The latest Buf updates on your PR.\n\n${summary.stringify()}`);
     }
     // Write the summary to a file defined by GITHUB_STEP_SUMMARY.
     // NB: Write empties the buffer and must be after the comment.
@@ -45775,13 +45772,24 @@ main()
 function createSummary(inputs, steps, moduleNames) {
     const table = [
         [
-            { data: "Name", header: true },
-            { data: "Status", header: true },
+            { data: "Build", header: true },
+            { data: "Format", header: true },
+            { data: "Lint", header: true },
+            { data: "Breaking", header: true },
+            { data: "Run", header: true },
+            { data: "Updated (UTC)", header: true },
         ],
-        ["build", message(steps.build)],
-        ["lint", message(steps.lint)],
-        ["format", message(steps.format)],
-        ["breaking", message(steps.breaking)],
+        [
+            message(steps.build),
+            message(steps.format),
+            message(steps.lint),
+            message(steps.breaking),
+            `<a href="${lib_github.context.serverUrl}/${lib_github.context.repo.owner}/${lib_github.context.repo.repo}/actions/runs/${lib_github.context.runId}">view</a>`,
+            new Date().toLocaleString("en-US", {
+                timeZone: "UTC",
+                hour12: true,
+            }),
+        ],
     ];
     // If push or archive is enabled add a link to the registry.
     let output = core.summary.addTable(table);
@@ -46064,9 +46072,6 @@ function message(result) {
         default:
             return "<code>🚫 cancelled</code>";
     }
-}
-function linkToRun(message) {
-    return `<a href="${lib_github.context.serverUrl}/${lib_github.context.repo.owner}/${lib_github.context.repo.repo}/actions/runs/${lib_github.context.runId}">${message}</a>`;
 }
 
 })();

--- a/dist/index.js
+++ b/dist/index.js
@@ -45814,15 +45814,15 @@ function createSummary(inputs, steps) {
             message(steps.format?.status),
             message(steps.breaking?.status),
             message(steps.lint?.status),
-            `[${lib_github.context.serverUrl}/${lib_github.context.repo.owner}/${lib_github.context.repo.repo}/actions/runs/${lib_github.context.runId}](${lib_github.context.serverUrl}/${lib_github.context.repo.owner}/${lib_github.context.repo.repo}/actions/runs/${lib_github.context.runId})
-${lib_github.context.serverUrl}/${lib_github.context.repo.owner}/${lib_github.context.repo.repo}/actions/runs/${lib_github.context.runId}`,
+            `<a href="${lib_github.context.serverUrl}/${lib_github.context.repo.owner}/${lib_github.context.repo.repo}/actions/runs/${lib_github.context.runId}">View</a>`,
             new Date().toISOString(),
         ],
     ];
     // If push or archive is enabled add a link to the registry.
     //if (inputs.push) table.push(["push", message(steps.push?.status)]);
     //if (inputs.archive) table.push(["archive", message(steps.archive?.status)]);
-    return core.summary.addTable(table);
+    return core.summary.addTable(table)
+        .addLink("View run", `${lib_github.context.serverUrl}/${lib_github.context.repo.owner}/${lib_github.context.repo.repo}/actions/runs/${lib_github.context.runId}`);
 }
 // runWorkflow runs the buf workflow. It returns the results of each step.
 // First, it builds the input. If the build fails, the workflow stops.

--- a/dist/index.js
+++ b/dist/index.js
@@ -45806,7 +45806,7 @@ function createSummary(inputs, steps) {
             { data: "Format", header: true },
             { data: "Breaking", header: true },
             { data: "Lint", header: true },
-            { data: "Job", header: true },
+            { data: "Run", header: true },
             { data: "Updated (UTC)", header: true },
         ],
         [
@@ -45814,7 +45814,7 @@ function createSummary(inputs, steps) {
             message(steps.format?.status),
             message(steps.breaking?.status),
             message(steps.lint?.status),
-            `${lib_github.context.serverUrl}/${lib_github.context.repo.owner}/${lib_github.context.repo.repo}/actions/runs/${lib_github.context.runId}`,
+            `<a href={"${lib_github.context.serverUrl}/${lib_github.context.repo.owner}/${lib_github.context.repo.repo}/actions/runs/${lib_github.context.runId}">${lib_github.context.runId}</a>`,
             new Date().toISOString(),
         ],
     ];

--- a/dist/index.js
+++ b/dist/index.js
@@ -45608,56 +45608,10 @@ async function downloadBuf(version) {
 // commentTag is the tag used to identify the comment. This is a non-visible
 // string injected into the comment body.
 const commentTag = "<!-- Buf results -->";
-// commentOnPR comments on the PR with the summary of the Buf results. The
-// summary should be a markdown formatted string. This function returns true if
-// the comment was successfully created or updated. On failure, it returns
-// false but does not throw an error.
-/*export async function commentOnPR(
-  context: Context,
-  github: InstanceType<typeof GitHub>,
-  summary: string,
-): Promise<boolean> {
-  const comment = `The latest Buf updates on your PR.\n\n${summary}`;
-  try {
-    const { owner, repo } = context.repo;
-    const prNumber = context.payload.pull_request?.number;
-    if (!prNumber) {
-      core.info("This is not a PR, skipping commenting");
-      return false;
-    }
-    const content = {
-      owner: owner,
-      repo: repo,
-      body: comment + commentTag,
-    };
-    // Check if a comment already exists and update it.
-    const comments = await github.paginate(github.rest.issues.listComments, {
-      owner: owner,
-      repo: repo,
-      issue_number: prNumber,
-    });
-    const previousComment = comments.find((comment) =>
-      comment.body?.includes(commentTag),
-    );
-    if (previousComment) {
-      await github.rest.issues.updateComment({
-        ...content,
-        comment_id: previousComment.id,
-      });
-      core.info(`Updated comment ${previousComment.id} on PR #${prNumber}`);
-    } else {
-      await github.rest.issues.createComment({
-        ...content,
-        issue_number: prNumber,
-      });
-      core.info(`Commented on PR #${prNumber}`);
-    }
-    return true;
-  } catch (error) {
-    core.info(`Error occurred while commenting on PR: ${error}`);
-    return false;
-  }
-}*/
+// findCommentOnPR finds the comment on the PR that contains the Buf results.
+// If the comment is found, it returns the comment ID. If the comment is not
+// found, it returns undefined. On failure, it returns undefined but does not
+// throw an error.
 async function findCommentOnPR(context, github) {
     const { owner, repo } = context.repo;
     const prNumber = context.payload.pull_request?.number;
@@ -45677,6 +45631,10 @@ async function findCommentOnPR(context, github) {
     }
     return undefined;
 }
+// commentOnPR comments on the PR with the summary of the Buf results. The
+// summary should be a markdown formatted string. This function returns true if
+// the comment was successfully created or updated. On failure, it returns
+// false but does not throw an error.
 async function commentOnPR(context, github, commentID, body) {
     const { owner, repo } = context.repo;
     const prNumber = context.payload.pull_request?.number;

--- a/dist/index.js
+++ b/dist/index.js
@@ -45785,9 +45785,14 @@ function createSummary(inputs, steps, moduleNames) {
             message(steps.lint),
             message(steps.breaking),
             `<a href="${lib_github.context.serverUrl}/${lib_github.context.repo.owner}/${lib_github.context.repo.repo}/actions/runs/${lib_github.context.runId}">view</a>`,
-            new Date().toLocaleString("en-US", {
-                timeZone: "UTC",
+            new Date().toLocaleString("en-GB", {
+                day: "numeric",
+                month: "short",
+                year: "numeric",
+                hour: "numeric",
+                minute: "numeric",
                 hour12: true,
+                timeZone: "UTC",
             }),
         ],
     ];

--- a/dist/index.js
+++ b/dist/index.js
@@ -45785,7 +45785,7 @@ function createSummary(inputs, steps, moduleNames) {
             message(steps.lint),
             message(steps.breaking),
             `<a href="${lib_github.context.serverUrl}/${lib_github.context.repo.owner}/${lib_github.context.repo.repo}/actions/runs/${lib_github.context.runId}">view</a>`,
-            new Date().toLocaleString("en-GB", {
+            new Date().toLocaleString("en-US", {
                 day: "numeric",
                 month: "short",
                 year: "numeric",

--- a/dist/index.js
+++ b/dist/index.js
@@ -45768,6 +45768,12 @@ function parseModuleName(moduleName) {
 async function main() {
     const inputs = getInputs();
     const github = (0,lib_github.getOctokit)(core.getInput("github_token"));
+    // Find the comment on the PR, and update it with a running message.
+    let commentID;
+    if (inputs.pr_comment) {
+        commentID = await findCommentOnPR(lib_github.context, github);
+        commentID = await commentOnPR(lib_github.context, github, commentID, "Running...");
+    }
     const [bufPath, bufVersion] = await installBuf(github, inputs.version);
     core.setOutput(Outputs.BufVersion, bufVersion);
     await login(bufPath, inputs);
@@ -45775,19 +45781,13 @@ async function main() {
         core.info("Setup only, skipping steps");
         return;
     }
-    // Find the comment on the PR, and update it with a running message.
-    let commentID;
-    if (inputs.pr_comment) {
-        commentID = await findCommentOnPR(lib_github.context, github);
-        commentID = await commentOnPR(lib_github.context, github, commentID, "Running...");
-    }
     // Run the buf workflow.
     const steps = await runWorkflow(bufPath, inputs);
     // Create a summary of the steps.
     const summary = createSummary(inputs, steps);
     // Comment on the PR with the summary, if requested.
     if (inputs.pr_comment) {
-        await commentOnPR(lib_github.context, github, commentID, summary.stringify());
+        await commentOnPR(lib_github.context, github, commentID, `The latest Buf updates on your PR.\n\n${summary.stringify()}`);
     }
     // Write the summary to a file defined by GITHUB_STEP_SUMMARY.
     // NB: Write empties the buffer and must be after the comment.

--- a/dist/index.js
+++ b/dist/index.js
@@ -45835,18 +45835,15 @@ function createSummary(inputs, steps, moduleNames) {
             }),
         ],
     ];
-    console.log("moduleNames", moduleNames);
     // If push or archive is enabled add a link to the registry.
-    //if (inputs.push) table.push(["push", message(steps.push?.status)]);
-    //if (inputs.archive) table.push(["archive", message(steps.archive?.status)]);
     let output = core.summary.addTable(table);
     if (inputs.push && moduleNames.length > 0) {
         const modules = moduleNames.map((moduleName) => `<a href="https://${moduleName.name}">${moduleName.name}</a>`);
-        output = output.addRaw(`Pushed ${modules.join(", ")} to registry.`, true);
+        output = output.addRaw(`Pushed to ${modules.join(", ")}.`, true);
     }
     if (inputs.archive && moduleNames.length > 0) {
         const modules = moduleNames.map((moduleName) => `<a href="https://${moduleName.name}">${moduleName.name}</a>`);
-        output = output.addRaw(`Archived ${modules.join(", ")} with ${inputs.archive_labels.join(", ")} labels.`, true);
+        output = output.addRaw(`Archived labels ${inputs.archive_labels.join(", ")} to ${modules.join(", ")}.`, true);
     }
     return output;
 }
@@ -46111,13 +46108,13 @@ function pass() {
 function message(result) {
     switch (result?.status) {
         case Status.Passed:
-            return "✅ passed";
+            return "<code>✅ passed</code>";
         case Status.Failed:
-            return `❌ failed (${result.stdout.split("\n").length - 1})`;
+            return `<code>❌ failed (${result.stdout.split("\n").length - 1})</code>`;
         case Status.Skipped:
-            return "⏩ skipped";
+            return "<code>⏩ skipped</code>";
         default:
-            return "🚫 cancelled";
+            return "<code>🚫 cancelled</code>";
     }
 }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -45806,7 +45806,7 @@ function createSummary(inputs, steps) {
             { data: "Format", header: true },
             { data: "Breaking", header: true },
             { data: "Lint", header: true },
-            { data: "Job", header: true },
+            { data: "Run", header: true },
             { data: "Updated (UTC)", header: true },
         ],
         [
@@ -45814,10 +45814,9 @@ function createSummary(inputs, steps) {
             message(steps.format),
             message(steps.breaking),
             message(steps.lint),
-            `<a href="${lib_github.context.serverUrl}/${lib_github.context.repo.owner}/${lib_github.context.repo.repo}/actions/runs/${lib_github.context.runId}/job/${lib_github.context.job}">View</a>`,
+            `<a href="${lib_github.context.serverUrl}/${lib_github.context.repo.owner}/${lib_github.context.repo.repo}/actions/runs/${lib_github.context.runId}">View</a>`,
             new Date().toLocaleString("en-US", {
-                hour: "numeric",
-                minute: "numeric",
+                timeZone: "UTC",
                 hour12: true,
             }),
         ],

--- a/dist/index.js
+++ b/dist/index.js
@@ -45818,16 +45818,16 @@ function createSummary(inputs, steps, moduleNames) {
         [
             { data: "Build", header: true },
             { data: "Format", header: true },
-            { data: "Breaking", header: true },
             { data: "Lint", header: true },
+            { data: "Breaking", header: true },
             { data: "Run", header: true },
             { data: "Updated (UTC)", header: true },
         ],
         [
             message(steps.build),
             message(steps.format),
-            message(steps.breaking),
             message(steps.lint),
+            message(steps.breaking),
             `<a href="${lib_github.context.serverUrl}/${lib_github.context.repo.owner}/${lib_github.context.repo.repo}/actions/runs/${lib_github.context.runId}">view</a>`,
             new Date().toLocaleString("en-US", {
                 timeZone: "UTC",

--- a/dist/index.js
+++ b/dist/index.js
@@ -9898,6 +9898,15 @@ function onceStrict (fn) {
 
 /***/ }),
 
+/***/ 4833:
+/***/ ((module) => {
+
+"use strict";
+function _typeof(obj){"@babel/helpers - typeof";return _typeof="function"==typeof Symbol&&"symbol"==typeof Symbol.iterator?function(obj){return typeof obj}:function(obj){return obj&&"function"==typeof Symbol&&obj.constructor===Symbol&&obj!==Symbol.prototype?"symbol":typeof obj},_typeof(obj)}function _createForOfIteratorHelper(o,allowArrayLike){var it=typeof Symbol!=="undefined"&&o[Symbol.iterator]||o["@@iterator"];if(!it){if(Array.isArray(o)||(it=_unsupportedIterableToArray(o))||allowArrayLike&&o&&typeof o.length==="number"){if(it)o=it;var i=0;var F=function F(){};return{s:F,n:function n(){if(i>=o.length)return{done:true};return{done:false,value:o[i++]}},e:function e(_e2){throw _e2},f:F}}throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.")}var normalCompletion=true,didErr=false,err;return{s:function s(){it=it.call(o)},n:function n(){var step=it.next();normalCompletion=step.done;return step},e:function e(_e3){didErr=true;err=_e3},f:function f(){try{if(!normalCompletion&&it["return"]!=null)it["return"]()}finally{if(didErr)throw err}}}}function _defineProperty(obj,key,value){key=_toPropertyKey(key);if(key in obj){Object.defineProperty(obj,key,{value:value,enumerable:true,configurable:true,writable:true})}else{obj[key]=value}return obj}function _toPropertyKey(arg){var key=_toPrimitive(arg,"string");return _typeof(key)==="symbol"?key:String(key)}function _toPrimitive(input,hint){if(_typeof(input)!=="object"||input===null)return input;var prim=input[Symbol.toPrimitive];if(prim!==undefined){var res=prim.call(input,hint||"default");if(_typeof(res)!=="object")return res;throw new TypeError("@@toPrimitive must return a primitive value.")}return(hint==="string"?String:Number)(input)}function _slicedToArray(arr,i){return _arrayWithHoles(arr)||_iterableToArrayLimit(arr,i)||_unsupportedIterableToArray(arr,i)||_nonIterableRest()}function _nonIterableRest(){throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.")}function _unsupportedIterableToArray(o,minLen){if(!o)return;if(typeof o==="string")return _arrayLikeToArray(o,minLen);var n=Object.prototype.toString.call(o).slice(8,-1);if(n==="Object"&&o.constructor)n=o.constructor.name;if(n==="Map"||n==="Set")return Array.from(o);if(n==="Arguments"||/^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n))return _arrayLikeToArray(o,minLen)}function _arrayLikeToArray(arr,len){if(len==null||len>arr.length)len=arr.length;for(var i=0,arr2=new Array(len);i<len;i++){arr2[i]=arr[i]}return arr2}function _iterableToArrayLimit(arr,i){var _i=null==arr?null:"undefined"!=typeof Symbol&&arr[Symbol.iterator]||arr["@@iterator"];if(null!=_i){var _s,_e,_x,_r,_arr=[],_n=!0,_d=!1;try{if(_x=(_i=_i.call(arr)).next,0===i){if(Object(_i)!==_i)return;_n=!1}else for(;!(_n=(_s=_x.call(_i)).done)&&(_arr.push(_s.value),_arr.length!==i);_n=!0){;}}catch(err){_d=!0,_e=err}finally{try{if(!_n&&null!=_i["return"]&&(_r=_i["return"](),Object(_r)!==_r))return}finally{if(_d)throw _e}}return _arr}}function _arrayWithHoles(arr){if(Array.isArray(arr))return arr}module.exports=function(input){if(!input)return[];if(typeof input!=="string"||input.match(/^\s+$/))return[];var lines=input.split("\n");if(lines.length===0)return[];var files=[];var currentFile=null;var currentChunk=null;var deletedLineCounter=0;var addedLineCounter=0;var currentFileChanges=null;var normal=function normal(line){var _currentChunk;(_currentChunk=currentChunk)===null||_currentChunk===void 0?void 0:_currentChunk.changes.push({type:"normal",normal:true,ln1:deletedLineCounter++,ln2:addedLineCounter++,content:line});currentFileChanges.oldLines--;currentFileChanges.newLines--};var start=function start(line){var _parseFiles;var _ref=(_parseFiles=parseFiles(line))!==null&&_parseFiles!==void 0?_parseFiles:[],_ref2=_slicedToArray(_ref,2),fromFileName=_ref2[0],toFileName=_ref2[1];currentFile={chunks:[],deletions:0,additions:0,from:fromFileName,to:toFileName};files.push(currentFile)};var restart=function restart(){if(!currentFile||currentFile.chunks.length)start()};var newFile=function newFile(_,match){restart();currentFile["new"]=true;currentFile.newMode=match[1];currentFile.from="/dev/null"};var deletedFile=function deletedFile(_,match){restart();currentFile.deleted=true;currentFile.oldMode=match[1];currentFile.to="/dev/null"};var oldMode=function oldMode(_,match){restart();currentFile.oldMode=match[1]};var newMode=function newMode(_,match){restart();currentFile.newMode=match[1]};var index=function index(line,match){restart();currentFile.index=line.split(" ").slice(1);if(match[1]){currentFile.oldMode=currentFile.newMode=match[1].trim()}};var fromFile=function fromFile(line){restart();currentFile.from=parseOldOrNewFile(line)};var toFile=function toFile(line){restart();currentFile.to=parseOldOrNewFile(line)};var toNumOfLines=function toNumOfLines(number){return+(number||1)};var chunk=function chunk(line,match){if(!currentFile){start(line)}var _match$slice=match.slice(1),_match$slice2=_slicedToArray(_match$slice,4),oldStart=_match$slice2[0],oldNumLines=_match$slice2[1],newStart=_match$slice2[2],newNumLines=_match$slice2[3];deletedLineCounter=+oldStart;addedLineCounter=+newStart;currentChunk={content:line,changes:[],oldStart:+oldStart,oldLines:toNumOfLines(oldNumLines),newStart:+newStart,newLines:toNumOfLines(newNumLines)};currentFileChanges={oldLines:toNumOfLines(oldNumLines),newLines:toNumOfLines(newNumLines)};currentFile.chunks.push(currentChunk)};var del=function del(line){if(!currentChunk)return;currentChunk.changes.push({type:"del",del:true,ln:deletedLineCounter++,content:line});currentFile.deletions++;currentFileChanges.oldLines--};var add=function add(line){if(!currentChunk)return;currentChunk.changes.push({type:"add",add:true,ln:addedLineCounter++,content:line});currentFile.additions++;currentFileChanges.newLines--};var eof=function eof(line){var _currentChunk$changes3;if(!currentChunk)return;var _currentChunk$changes=currentChunk.changes.slice(-1),_currentChunk$changes2=_slicedToArray(_currentChunk$changes,1),mostRecentChange=_currentChunk$changes2[0];currentChunk.changes.push((_currentChunk$changes3={type:mostRecentChange.type},_defineProperty(_currentChunk$changes3,mostRecentChange.type,true),_defineProperty(_currentChunk$changes3,"ln1",mostRecentChange.ln1),_defineProperty(_currentChunk$changes3,"ln2",mostRecentChange.ln2),_defineProperty(_currentChunk$changes3,"ln",mostRecentChange.ln),_defineProperty(_currentChunk$changes3,"content",line),_currentChunk$changes3))};var schemaHeaders=[[/^diff\s/,start],[/^new file mode (\d+)$/,newFile],[/^deleted file mode (\d+)$/,deletedFile],[/^old mode (\d+)$/,oldMode],[/^new mode (\d+)$/,newMode],[/^index\s[\da-zA-Z]+\.\.[\da-zA-Z]+(\s(\d+))?$/,index],[/^---\s/,fromFile],[/^\+\+\+\s/,toFile],[/^@@\s+-(\d+),?(\d+)?\s+\+(\d+),?(\d+)?\s@@/,chunk],[/^\\ No newline at end of file$/,eof]];var schemaContent=[[/^\\ No newline at end of file$/,eof],[/^-/,del],[/^\+/,add],[/^\s+/,normal]];var parseContentLine=function parseContentLine(line){for(var _i2=0,_schemaContent=schemaContent;_i2<_schemaContent.length;_i2++){var _schemaContent$_i=_slicedToArray(_schemaContent[_i2],2),pattern=_schemaContent$_i[0],handler=_schemaContent$_i[1];var match=line.match(pattern);if(match){handler(line,match);break}}if(currentFileChanges.oldLines===0&&currentFileChanges.newLines===0){currentFileChanges=null}};var parseHeaderLine=function parseHeaderLine(line){for(var _i3=0,_schemaHeaders=schemaHeaders;_i3<_schemaHeaders.length;_i3++){var _schemaHeaders$_i=_slicedToArray(_schemaHeaders[_i3],2),pattern=_schemaHeaders$_i[0],handler=_schemaHeaders$_i[1];var match=line.match(pattern);if(match){handler(line,match);break}}};var parseLine=function parseLine(line){if(currentFileChanges){parseContentLine(line)}else{parseHeaderLine(line)}return};var _iterator=_createForOfIteratorHelper(lines),_step;try{for(_iterator.s();!(_step=_iterator.n()).done;){var line=_step.value;parseLine(line)}}catch(err){_iterator.e(err)}finally{_iterator.f()}return files};var fileNameDiffRegex=/(a|i|w|c|o|1|2)\/.*(?=["']? ["']?(b|i|w|c|o|1|2)\/)|(b|i|w|c|o|1|2)\/.*$/g;var gitFileHeaderRegex=/^(a|b|i|w|c|o|1|2)\//;var parseFiles=function parseFiles(line){var fileNames=line===null||line===void 0?void 0:line.match(fileNameDiffRegex);return fileNames===null||fileNames===void 0?void 0:fileNames.map(function(fileName){return fileName.replace(gitFileHeaderRegex,"").replace(/("|')$/,"")})};var qoutedFileNameRegex=/^\\?['"]|\\?['"]$/g;var parseOldOrNewFile=function parseOldOrNewFile(line){var fileName=leftTrimChars(line,"-+").trim();fileName=removeTimeStamp(fileName);return fileName.replace(qoutedFileNameRegex,"").replace(gitFileHeaderRegex,"")};var leftTrimChars=function leftTrimChars(string,trimmingChars){string=makeString(string);if(!trimmingChars&&String.prototype.trimLeft)return string.trimLeft();var trimmingString=formTrimmingString(trimmingChars);return string.replace(new RegExp("^".concat(trimmingString,"+")),"")};var timeStampRegex=/\t.*|\d{4}-\d\d-\d\d\s\d\d:\d\d:\d\d(.\d+)?\s(\+|-)\d\d\d\d/;var removeTimeStamp=function removeTimeStamp(string){var timeStamp=timeStampRegex.exec(string);if(timeStamp){string=string.substring(0,timeStamp.index).trim()}return string};var formTrimmingString=function formTrimmingString(trimmingChars){if(trimmingChars===null||trimmingChars===undefined)return"\\s";else if(trimmingChars instanceof RegExp)return trimmingChars.source;return"[".concat(makeString(trimmingChars).replace(/([.*+?^=!:${}()|[\]/\\])/g,"\\$1"),"]")};var makeString=function makeString(itemToConvert){return(itemToConvert!==null&&itemToConvert!==void 0?itemToConvert:"")+""};
+
+
+/***/ }),
+
 /***/ 1532:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
@@ -45360,6 +45369,8 @@ const LabelService = {
 };
 
 
+// EXTERNAL MODULE: ./node_modules/parse-diff/index.js
+var parse_diff = __nccwpck_require__(4833);
 ;// CONCATENATED MODULE: ./src/inputs.ts
 // Copyright 2024 Buf Technologies, Inc.
 //
@@ -45764,6 +45775,7 @@ function parseModuleName(moduleName) {
 
 
 
+
 // main is the entrypoint for the action.
 async function main() {
     const inputs = getInputs();
@@ -45775,10 +45787,12 @@ async function main() {
         core.info("Setup only, skipping steps");
         return;
     }
+    // Parse the module names from the input.
+    const moduleNames = await parseModuleNames(bufPath, inputs.input);
     // Run the buf workflow.
-    const steps = await runWorkflow(bufPath, inputs);
+    const steps = await runWorkflow(bufPath, inputs, moduleNames);
     // Create a summary of the steps.
-    const summary = createSummary(inputs, steps);
+    const summary = createSummary(inputs, steps, moduleNames);
     // Comment on the PR with the summary, if requested.
     if (inputs.pr_comment) {
         const commentID = await findCommentOnPR(lib_github.context, github);
@@ -45799,7 +45813,7 @@ main()
     .then(() => core.debug(`done in ${process.uptime()} s`));
 // createSummary creates a GitHub summary of the steps. The summary is a table
 // with the name and status of each step.
-function createSummary(inputs, steps) {
+function createSummary(inputs, steps, moduleNames) {
     const table = [
         [
             { data: "Build", header: true },
@@ -45821,6 +45835,7 @@ function createSummary(inputs, steps) {
             }),
         ],
     ];
+    console.log("moduleNames", moduleNames);
     // If push or archive is enabled add a link to the registry.
     //if (inputs.push) table.push(["push", message(steps.push?.status)]);
     //if (inputs.archive) table.push(["archive", message(steps.archive?.status)]);
@@ -45830,7 +45845,7 @@ function createSummary(inputs, steps) {
 // First, it builds the input. If the build fails, the workflow stops.
 // Next, it runs lint, format, and breaking checks. If any of these fail, the workflow stops.
 // Finally, it pushes or archives the label to the registry.
-async function runWorkflow(bufPath, inputs) {
+async function runWorkflow(bufPath, inputs, moduleNames) {
     const steps = {};
     steps.build = await build(bufPath, inputs);
     if (steps.build.status == Status.Failed) {
@@ -45847,7 +45862,6 @@ async function runWorkflow(bufPath, inputs) {
     if (checks.some((result) => result.status == Status.Failed)) {
         return steps;
     }
-    const moduleNames = await parseModuleNames(bufPath, inputs.input);
     steps.push = await push(bufPath, inputs, moduleNames);
     steps.archive = await archive(inputs, moduleNames);
     return steps;
@@ -45924,7 +45938,23 @@ async function format(bufPath, inputs) {
     for (const path of inputs.exclude_paths) {
         args.push("--exclude-path", path);
     }
-    return run(bufPath, args);
+    const result = await run(bufPath, args);
+    if (result.status == Status.Failed) {
+        // If the format step fails, parse the diff and write github annotations.
+        const diff = parse_diff(result.stdout);
+        result.stdout = ""; // Clear the stdout.
+        console.log("diff", diff);
+        for (const file of diff) {
+            for (const chunk of file.chunks) {
+                for (const change of chunk.changes) {
+                    // TODO: Write annotations.
+                    console.log("change", change);
+                    //result.stdout += `::error file=${name},line=${line},title=${title}::${message}\n`;
+                }
+            }
+        }
+    }
+    return result;
 }
 // breaking runs the "buf breaking" step.
 async function breaking(bufPath, inputs) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -45601,47 +45601,97 @@ const commentTag = "<!-- Buf results -->";
 // summary should be a markdown formatted string. This function returns true if
 // the comment was successfully created or updated. On failure, it returns
 // false but does not throw an error.
-async function commentOnPR(context, github, summary) {
-    const comment = `The latest Buf updates on your PR.\n\n${summary}`;
-    try {
-        const { owner, repo } = context.repo;
-        const prNumber = context.payload.pull_request?.number;
-        if (!prNumber) {
-            core.info("This is not a PR, skipping commenting");
-            return false;
-        }
-        const content = {
-            owner: owner,
-            repo: repo,
-            body: comment + commentTag,
-        };
-        // Check if a comment already exists and update it.
-        const comments = await github.paginate(github.rest.issues.listComments, {
-            owner: owner,
-            repo: repo,
-            issue_number: prNumber,
+/*export async function commentOnPR(
+  context: Context,
+  github: InstanceType<typeof GitHub>,
+  summary: string,
+): Promise<boolean> {
+  const comment = `The latest Buf updates on your PR.\n\n${summary}`;
+  try {
+    const { owner, repo } = context.repo;
+    const prNumber = context.payload.pull_request?.number;
+    if (!prNumber) {
+      core.info("This is not a PR, skipping commenting");
+      return false;
+    }
+    const content = {
+      owner: owner,
+      repo: repo,
+      body: comment + commentTag,
+    };
+    // Check if a comment already exists and update it.
+    const comments = await github.paginate(github.rest.issues.listComments, {
+      owner: owner,
+      repo: repo,
+      issue_number: prNumber,
+    });
+    const previousComment = comments.find((comment) =>
+      comment.body?.includes(commentTag),
+    );
+    if (previousComment) {
+      await github.rest.issues.updateComment({
+        ...content,
+        comment_id: previousComment.id,
+      });
+      core.info(`Updated comment ${previousComment.id} on PR #${prNumber}`);
+    } else {
+      await github.rest.issues.createComment({
+        ...content,
+        issue_number: prNumber,
+      });
+      core.info(`Commented on PR #${prNumber}`);
+    }
+    return true;
+  } catch (error) {
+    core.info(`Error occurred while commenting on PR: ${error}`);
+    return false;
+  }
+}*/
+async function findCommentOnPR(context, github) {
+    const { owner, repo } = context.repo;
+    const prNumber = context.payload.pull_request?.number;
+    if (!prNumber) {
+        core.info("This is not a PR, skipping finding comment");
+        return undefined;
+    }
+    const comments = await github.paginate(github.rest.issues.listComments, {
+        owner: owner,
+        repo: repo,
+        issue_number: prNumber,
+    });
+    const previousComment = comments.find((comment) => comment.body?.includes(commentTag));
+    if (previousComment) {
+        core.info(`Found previous comment ${previousComment.id}`);
+        return previousComment.id;
+    }
+    return undefined;
+}
+async function commentOnPR(context, github, commentID, body) {
+    const { owner, repo } = context.repo;
+    const prNumber = context.payload.pull_request?.number;
+    if (!prNumber) {
+        core.info("This is not a PR, skipping commenting");
+        return undefined;
+    }
+    const content = {
+        owner: owner,
+        repo: repo,
+        body: body + commentTag,
+    };
+    if (commentID) {
+        await github.rest.issues.updateComment({
+            ...content,
+            comment_id: commentID,
         });
-        const previousComment = comments.find((comment) => comment.body?.includes(commentTag));
-        if (previousComment) {
-            await github.rest.issues.updateComment({
-                ...content,
-                comment_id: previousComment.id,
-            });
-            core.info(`Updated comment ${previousComment.id} on PR #${prNumber}`);
-        }
-        else {
-            await github.rest.issues.createComment({
-                ...content,
-                issue_number: prNumber,
-            });
-            core.info(`Commented on PR #${prNumber}`);
-        }
-        return true;
+        core.info(`Updated comment ${commentID} on PR #${prNumber}`);
+        return commentID;
     }
-    catch (error) {
-        core.info(`Error occurred while commenting on PR: ${error}`);
-        return false;
-    }
+    const comment = await github.rest.issues.createComment({
+        ...content,
+        issue_number: prNumber,
+    });
+    core.info(`Commented ${comment.data.id} on PR #${prNumber}`);
+    return comment.data.id;
 }
 
 ;// CONCATENATED MODULE: ./src/config.ts
@@ -45725,13 +45775,19 @@ async function main() {
         core.info("Setup only, skipping steps");
         return;
     }
+    // Find the comment on the PR, and update it with a running message.
+    let commentID;
+    if (inputs.pr_comment) {
+        commentID = await findCommentOnPR(lib_github.context, github);
+        commentID = await commentOnPR(lib_github.context, github, commentID, "Running...");
+    }
     // Run the buf workflow.
     const steps = await runWorkflow(bufPath, inputs);
     // Create a summary of the steps.
     const summary = createSummary(inputs, steps);
     // Comment on the PR with the summary, if requested.
     if (inputs.pr_comment) {
-        await commentOnPR(lib_github.context, github, summary.stringify());
+        await commentOnPR(lib_github.context, github, commentID, summary.stringify());
     }
     // Write the summary to a file defined by GITHUB_STEP_SUMMARY.
     // NB: Write empties the buffer and must be after the comment.

--- a/dist/index.js
+++ b/dist/index.js
@@ -45807,6 +45807,7 @@ function createSummary(inputs, steps) {
             { data: "Breaking", header: true },
             { data: "Lint", header: true },
             { data: "Job", header: true },
+            { data: "Updated (UTC)", header: true },
         ],
         [
             message(steps.build),
@@ -45814,13 +45815,17 @@ function createSummary(inputs, steps) {
             message(steps.breaking),
             message(steps.lint),
             `<a href="${lib_github.context.serverUrl}/${lib_github.context.repo.owner}/${lib_github.context.repo.repo}/actions/runs/${lib_github.context.runId}/job/${lib_github.context.job}">View</a>`,
+            new Date().toLocaleString("en-US", {
+                hour: "numeric",
+                minute: "numeric",
+                hour12: true,
+            }),
         ],
     ];
     // If push or archive is enabled add a link to the registry.
     //if (inputs.push) table.push(["push", message(steps.push?.status)]);
     //if (inputs.archive) table.push(["archive", message(steps.archive?.status)]);
-    return core.summary.addTable(table)
-        .addLink("View run", `${lib_github.context.serverUrl}/${lib_github.context.repo.owner}/${lib_github.context.repo.repo}/actions/runs/${lib_github.context.runId}`);
+    return core.summary.addTable(table);
 }
 // runWorkflow runs the buf workflow. It returns the results of each step.
 // First, it builds the input. If the build fails, the workflow stops.

--- a/dist/index.js
+++ b/dist/index.js
@@ -45942,10 +45942,9 @@ async function format(bufPath, inputs) {
     if (result.status == Status.Failed && result.stdout.startsWith("diff")) {
         // If the format step fails, parse the diff and write github annotations.
         const diff = parse_diff(result.stdout);
-        result.stdout = ""; // Clear the stdout.
-        console.log("diff", diff);
+        result.stdout = ""; // Clear the stdout to count the number of changes.
         for (const file of diff) {
-            result.stdout += `::error file=${file.to}::Format failed -${file.deletions} +${file.additions} changes.\n`;
+            result.stdout += `::error file=${file.to},title=Buf format::Diff -${file.deletions}/+${file.additions}.\n`;
         }
         console.log(result.stdout);
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@connectrpc/connect": "^1.4.0",
         "@connectrpc/connect-web": "^1.4.0",
         "@octokit/webhooks-definitions": "^3.67.3",
+        "parse-diff": "^0.11.1",
         "semver": "^7.6.1"
       },
       "devDependencies": {
@@ -1461,6 +1462,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/parse-diff": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/parse-diff/-/parse-diff-0.11.1.tgz",
+      "integrity": "sha512-Oq4j8LAOPOcssanQkIjxosjATBIEJhCxMCxPhMu+Ci4wdNmAEdx0O+a7gzbR2PyKXgKPvRLIN5g224+dJAsKHA==",
+      "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@connectrpc/connect": "^1.4.0",
     "@connectrpc/connect-web": "^1.4.0",
     "@octokit/webhooks-definitions": "^3.67.3",
+    "parse-diff": "^0.11.1",
     "semver": "^7.6.1"
   }
 }

--- a/src/comment.ts
+++ b/src/comment.ts
@@ -22,8 +22,7 @@ const commentTag = "<!-- Buf results -->";
 
 // findCommentOnPR finds the comment on the PR that contains the Buf results.
 // If the comment is found, it returns the comment ID. If the comment is not
-// found, it returns undefined. On failure, it returns undefined but does not
-// throw an error.
+// found, it returns undefined.
 export async function findCommentOnPR(
   context: Context,
   github: InstanceType<typeof GitHub>,
@@ -51,8 +50,7 @@ export async function findCommentOnPR(
 
 // commentOnPR comments on the PR with the summary of the Buf results. The
 // summary should be a markdown formatted string. This function returns true if
-// the comment was successfully created or updated. On failure, it returns
-// false but does not throw an error.
+// the comment was successfully created or updated.
 export async function commentOnPR(
   context: Context,
   github: InstanceType<typeof GitHub>,

--- a/src/comment.ts
+++ b/src/comment.ts
@@ -20,57 +20,10 @@ import { GitHub } from "@actions/github/lib/utils";
 // string injected into the comment body.
 const commentTag = "<!-- Buf results -->";
 
-// commentOnPR comments on the PR with the summary of the Buf results. The
-// summary should be a markdown formatted string. This function returns true if
-// the comment was successfully created or updated. On failure, it returns
-// false but does not throw an error.
-/*export async function commentOnPR(
-  context: Context,
-  github: InstanceType<typeof GitHub>,
-  summary: string,
-): Promise<boolean> {
-  const comment = `The latest Buf updates on your PR.\n\n${summary}`;
-  try {
-    const { owner, repo } = context.repo;
-    const prNumber = context.payload.pull_request?.number;
-    if (!prNumber) {
-      core.info("This is not a PR, skipping commenting");
-      return false;
-    }
-    const content = {
-      owner: owner,
-      repo: repo,
-      body: comment + commentTag,
-    };
-    // Check if a comment already exists and update it.
-    const comments = await github.paginate(github.rest.issues.listComments, {
-      owner: owner,
-      repo: repo,
-      issue_number: prNumber,
-    });
-    const previousComment = comments.find((comment) =>
-      comment.body?.includes(commentTag),
-    );
-    if (previousComment) {
-      await github.rest.issues.updateComment({
-        ...content,
-        comment_id: previousComment.id,
-      });
-      core.info(`Updated comment ${previousComment.id} on PR #${prNumber}`);
-    } else {
-      await github.rest.issues.createComment({
-        ...content,
-        issue_number: prNumber,
-      });
-      core.info(`Commented on PR #${prNumber}`);
-    }
-    return true;
-  } catch (error) {
-    core.info(`Error occurred while commenting on PR: ${error}`);
-    return false;
-  }
-}*/
-
+// findCommentOnPR finds the comment on the PR that contains the Buf results.
+// If the comment is found, it returns the comment ID. If the comment is not
+// found, it returns undefined. On failure, it returns undefined but does not
+// throw an error.
 export async function findCommentOnPR(
   context: Context,
   github: InstanceType<typeof GitHub>,
@@ -96,6 +49,10 @@ export async function findCommentOnPR(
   return undefined;
 }
 
+// commentOnPR comments on the PR with the summary of the Buf results. The
+// summary should be a markdown formatted string. This function returns true if
+// the comment was successfully created or updated. On failure, it returns
+// false but does not throw an error.
 export async function commentOnPR(
   context: Context,
   github: InstanceType<typeof GitHub>,

--- a/src/main.ts
+++ b/src/main.ts
@@ -98,15 +98,19 @@ function createSummary(inputs: Inputs, steps: Steps): typeof core.summary {
       message(steps.format?.status),
       message(steps.breaking?.status),
       message(steps.lint?.status),
-      `[${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})
-${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+      `<a href="${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}">View</a>`,
       new Date().toISOString(),
     ],
   ];
   // If push or archive is enabled add a link to the registry.
   //if (inputs.push) table.push(["push", message(steps.push?.status)]);
   //if (inputs.archive) table.push(["archive", message(steps.archive?.status)]);
-  return core.summary.addTable(table);
+  return core.summary
+    .addTable(table)
+    .addLink(
+      "View run",
+      `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+    );
 }
 
 // runWorkflow runs the buf workflow. It returns the results of each step.

--- a/src/main.ts
+++ b/src/main.ts
@@ -95,16 +95,16 @@ function createSummary(
     [
       { data: "Build", header: true },
       { data: "Format", header: true },
-      { data: "Breaking", header: true },
       { data: "Lint", header: true },
+      { data: "Breaking", header: true },
       { data: "Run", header: true },
       { data: "Updated (UTC)", header: true },
     ],
     [
       message(steps.build),
       message(steps.format),
-      message(steps.breaking),
       message(steps.lint),
+      message(steps.breaking),
       `<a href="${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}">view</a>`,
       new Date().toLocaleString("en-US", {
         timeZone: "UTC",

--- a/src/main.ts
+++ b/src/main.ts
@@ -52,7 +52,13 @@ async function main() {
       context,
       github,
       commentID,
-      `The latest Buf updates on your PR.\n\n${summary.stringify()}`,
+      `The latest Buf updates on your PR. ${linkToRun("View")} the run, last updated ${new Date().toLocaleString(
+        "en-US",
+        {
+          timeZone: "UTC",
+          hour12: true,
+        },
+      )}.\n\n${summary.stringify()}`,
     );
   }
   // Write the summary to a file defined by GITHUB_STEP_SUMMARY.
@@ -93,24 +99,13 @@ function createSummary(
 ): typeof core.summary {
   const table = [
     [
-      { data: "Build", header: true },
-      { data: "Format", header: true },
-      { data: "Lint", header: true },
-      { data: "Breaking", header: true },
-      { data: "Run", header: true },
-      { data: "Updated (UTC)", header: true },
+      { data: "Name", header: true },
+      { data: "Status", header: true },
     ],
-    [
-      message(steps.build),
-      message(steps.format),
-      message(steps.lint),
-      message(steps.breaking),
-      `<a href="${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}">view</a>`,
-      new Date().toLocaleString("en-US", {
-        timeZone: "UTC",
-        hour12: true,
-      }),
-    ],
+    ["build", message(steps.build)],
+    ["lint", message(steps.lint)],
+    ["format", message(steps.format)],
+    ["breaking", message(steps.breaking)],
   ];
   // If push or archive is enabled add a link to the registry.
   let output = core.summary.addTable(table);
@@ -443,4 +438,8 @@ function message(result: Result | undefined): string {
     default:
       return "<code>🚫 cancelled</code>";
   }
+}
+
+function linkToRun(message: string): string {
+  return `<a href="${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}">${message}</a>`;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -106,7 +106,7 @@ function createSummary(
       message(steps.lint),
       message(steps.breaking),
       `<a href="${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}">view</a>`,
-      new Date().toLocaleString("en-GB", {
+      new Date().toLocaleString("en-US", {
         day: "numeric",
         month: "short",
         year: "numeric",

--- a/src/main.ts
+++ b/src/main.ts
@@ -235,13 +235,7 @@ async function format(bufPath: string, inputs: Inputs): Promise<Result> {
     result.stdout = ""; // Clear the stdout.
     console.log("diff", diff);
     for (const file of diff) {
-      for (const chunk of file.chunks) {
-        for (const change of chunk.changes) {
-          // TODO: Write annotations.
-          console.log("change", change);
-          //result.stdout += `::error file=${name},line=${line},title=${title}::${message}\n`;
-        }
-      }
+      result.stdout += `::error file=${file.to}::Format failed -${file.deletions} +${file.additions} changes.\n`;
     }
   }
   return result;

--- a/src/main.ts
+++ b/src/main.ts
@@ -90,7 +90,8 @@ function createSummary(inputs: Inputs, steps: Steps): typeof core.summary {
       { data: "Format", header: true },
       { data: "Breaking", header: true },
       { data: "Lint", header: true },
-      { data: "Run", header: true },
+      { data: "Job", header: true },
+      { data: "Commit", header: true },
       { data: "Updated (UTC)", header: true },
     ],
     [
@@ -98,7 +99,7 @@ function createSummary(inputs: Inputs, steps: Steps): typeof core.summary {
       message(steps.format?.status),
       message(steps.breaking?.status),
       message(steps.lint?.status),
-      `<a href="${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}">View</a>`,
+      `<a href="${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}/job/${context.job}">View</a>`,
       new Date().toISOString(),
     ],
   ];

--- a/src/main.ts
+++ b/src/main.ts
@@ -91,6 +91,7 @@ function createSummary(inputs: Inputs, steps: Steps): typeof core.summary {
       { data: "Breaking", header: true },
       { data: "Lint", header: true },
       { data: "Job", header: true },
+      { data: "Updated (UTC)", header: true },
     ],
     [
       message(steps.build),
@@ -98,17 +99,17 @@ function createSummary(inputs: Inputs, steps: Steps): typeof core.summary {
       message(steps.breaking),
       message(steps.lint),
       `<a href="${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}/job/${context.job}">View</a>`,
+      new Date().toLocaleString("en-US", {
+        hour: "numeric",
+        minute: "numeric",
+        hour12: true,
+      }),
     ],
   ];
   // If push or archive is enabled add a link to the registry.
   //if (inputs.push) table.push(["push", message(steps.push?.status)]);
   //if (inputs.archive) table.push(["archive", message(steps.archive?.status)]);
-  return core.summary
-    .addTable(table)
-    .addLink(
-      "View run",
-      `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
-    );
+  return core.summary.addTable(table);
 }
 
 // runWorkflow runs the buf workflow. It returns the results of each step.

--- a/src/main.ts
+++ b/src/main.ts
@@ -98,7 +98,7 @@ function createSummary(inputs: Inputs, steps: Steps): typeof core.summary {
       message(steps.format),
       message(steps.breaking),
       message(steps.lint),
-      `<a href="${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}">View</a>`,
+      `<a href="${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}">view</a>`,
       new Date().toLocaleString("en-US", {
         timeZone: "UTC",
         hour12: true,
@@ -401,7 +401,7 @@ function message(result: Result | undefined): string {
     case Status.Passed:
       return "✅ passed";
     case Status.Failed:
-      return `❌ failed (${result.stderr.split("\n").length})`;
+      return `❌ failed (${result.stdout.split("\n").length})`;
     case Status.Skipped:
       return "⏩ skipped";
     default:

--- a/src/main.ts
+++ b/src/main.ts
@@ -90,7 +90,7 @@ function createSummary(inputs: Inputs, steps: Steps): typeof core.summary {
       { data: "Format", header: true },
       { data: "Breaking", header: true },
       { data: "Lint", header: true },
-      { data: "Job", header: true },
+      { data: "Run", header: true },
       { data: "Updated (UTC)", header: true },
     ],
     [
@@ -98,7 +98,7 @@ function createSummary(inputs: Inputs, steps: Steps): typeof core.summary {
       message(steps.format?.status),
       message(steps.breaking?.status),
       message(steps.lint?.status),
-      `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+      `<a href={"${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}">${context.runId}</a>`,
       new Date().toISOString(),
     ],
   ];

--- a/src/main.ts
+++ b/src/main.ts
@@ -91,16 +91,13 @@ function createSummary(inputs: Inputs, steps: Steps): typeof core.summary {
       { data: "Breaking", header: true },
       { data: "Lint", header: true },
       { data: "Job", header: true },
-      { data: "Commit", header: true },
-      { data: "Updated (UTC)", header: true },
     ],
     [
-      message(steps.build?.status),
-      message(steps.format?.status),
-      message(steps.breaking?.status),
-      message(steps.lint?.status),
+      message(steps.build),
+      message(steps.format),
+      message(steps.breaking),
+      message(steps.lint),
       `<a href="${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}/job/${context.job}">View</a>`,
-      new Date().toISOString(),
     ],
   ];
   // If push or archive is enabled add a link to the registry.
@@ -399,12 +396,12 @@ function pass(): Result {
 
 // message returns a human-readable message for the status. An undefined status
 // is considered cancelled.
-function message(status: Status | undefined): string {
-  switch (status) {
+function message(result: Result | undefined): string {
+  switch (result?.status) {
     case Status.Passed:
       return "✅ passed";
     case Status.Failed:
-      return "❌ failed";
+      return `❌ failed (${result.stderr.split("\n").length})`;
     case Status.Skipped:
       return "⏩ skipped";
     default:

--- a/src/main.ts
+++ b/src/main.ts
@@ -52,13 +52,7 @@ async function main() {
       context,
       github,
       commentID,
-      `The latest Buf updates on your PR. ${linkToRun("View")} the run, last updated ${new Date().toLocaleString(
-        "en-US",
-        {
-          timeZone: "UTC",
-          hour12: true,
-        },
-      )}.\n\n${summary.stringify()}`,
+      `The latest Buf updates on your PR.\n\n${summary.stringify()}`,
     );
   }
   // Write the summary to a file defined by GITHUB_STEP_SUMMARY.
@@ -99,13 +93,24 @@ function createSummary(
 ): typeof core.summary {
   const table = [
     [
-      { data: "Name", header: true },
-      { data: "Status", header: true },
+      { data: "Build", header: true },
+      { data: "Format", header: true },
+      { data: "Lint", header: true },
+      { data: "Breaking", header: true },
+      { data: "Run", header: true },
+      { data: "Updated (UTC)", header: true },
     ],
-    ["build", message(steps.build)],
-    ["lint", message(steps.lint)],
-    ["format", message(steps.format)],
-    ["breaking", message(steps.breaking)],
+    [
+      message(steps.build),
+      message(steps.format),
+      message(steps.lint),
+      message(steps.breaking),
+      `<a href="${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}">view</a>`,
+      new Date().toLocaleString("en-US", {
+        timeZone: "UTC",
+        hour12: true,
+      }),
+    ],
   ];
   // If push or archive is enabled add a link to the registry.
   let output = core.summary.addTable(table);
@@ -438,8 +443,4 @@ function message(result: Result | undefined): string {
     default:
       return "<code>🚫 cancelled</code>";
   }
-}
-
-function linkToRun(message: string): string {
-  return `<a href="${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}">${message}</a>`;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -116,7 +116,25 @@ function createSummary(
   // If push or archive is enabled add a link to the registry.
   //if (inputs.push) table.push(["push", message(steps.push?.status)]);
   //if (inputs.archive) table.push(["archive", message(steps.archive?.status)]);
-  return core.summary.addTable(table);
+  const output = core.summary.addTable(table);
+  if (inputs.push && moduleNames.length > 0) {
+    const modules = moduleNames.map(
+      (moduleName) =>
+        `<a href="https://${moduleName.name}">${moduleName.name}</a>`,
+    );
+    output.addRaw(`Pushed ${modules.join(", ")} to registry.`, true);
+  }
+  if (inputs.archive && moduleNames.length > 0) {
+    const modules = moduleNames.map(
+      (moduleName) =>
+        `<a href="https://${moduleName.name}">${moduleName.name}</a>`,
+    );
+    output.addRaw(
+      `Archived ${modules.join(", ")} with ${inputs.archive_labels.join(", ")} labels.`,
+      true,
+    );
+  }
+  return output;
 }
 
 // runWorkflow runs the buf workflow. It returns the results of each step.
@@ -234,7 +252,7 @@ async function format(bufPath: string, inputs: Inputs): Promise<Result> {
     const diff = parseDiff(result.stdout);
     result.stdout = ""; // Clear the stdout to count the number of changes.
     for (const file of diff) {
-      result.stdout += `::error file=${file.to},title=Buf format::Diff -${file.deletions}/+${file.additions}.\n`;
+      result.stdout += `::error file=${file.to}::Format diff -${file.deletions}/+${file.additions}.\n`;
     }
     console.log(result.stdout);
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -90,7 +90,7 @@ function createSummary(inputs: Inputs, steps: Steps): typeof core.summary {
       { data: "Format", header: true },
       { data: "Breaking", header: true },
       { data: "Lint", header: true },
-      { data: "Job", header: true },
+      { data: "Run", header: true },
       { data: "Updated (UTC)", header: true },
     ],
     [
@@ -98,10 +98,9 @@ function createSummary(inputs: Inputs, steps: Steps): typeof core.summary {
       message(steps.format),
       message(steps.breaking),
       message(steps.lint),
-      `<a href="${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}/job/${context.job}">View</a>`,
+      `<a href="${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}">View</a>`,
       new Date().toLocaleString("en-US", {
-        hour: "numeric",
-        minute: "numeric",
+        timeZone: "UTC",
         hour12: true,
       }),
     ],

--- a/src/main.ts
+++ b/src/main.ts
@@ -401,7 +401,7 @@ function message(result: Result | undefined): string {
     case Status.Passed:
       return "✅ passed";
     case Status.Failed:
-      return `❌ failed (${result.stdout.split("\n").length})`;
+      return `❌ failed (${result.stdout.split("\n").length - 1})`;
     case Status.Skipped:
       return "⏩ skipped";
     default:

--- a/src/main.ts
+++ b/src/main.ts
@@ -116,20 +116,20 @@ function createSummary(
   // If push or archive is enabled add a link to the registry.
   //if (inputs.push) table.push(["push", message(steps.push?.status)]);
   //if (inputs.archive) table.push(["archive", message(steps.archive?.status)]);
-  const output = core.summary.addTable(table);
+  let output = core.summary.addTable(table);
   if (inputs.push && moduleNames.length > 0) {
     const modules = moduleNames.map(
       (moduleName) =>
         `<a href="https://${moduleName.name}">${moduleName.name}</a>`,
     );
-    output.addRaw(`Pushed ${modules.join(", ")} to registry.`, true);
+    output = output.addRaw(`Pushed ${modules.join(", ")} to registry.`, true);
   }
   if (inputs.archive && moduleNames.length > 0) {
     const modules = moduleNames.map(
       (moduleName) =>
         `<a href="https://${moduleName.name}">${moduleName.name}</a>`,
     );
-    output.addRaw(
+    output = output.addRaw(
       `Archived ${modules.join(", ")} with ${inputs.archive_labels.join(", ")} labels.`,
       true,
     );

--- a/src/main.ts
+++ b/src/main.ts
@@ -106,9 +106,14 @@ function createSummary(
       message(steps.lint),
       message(steps.breaking),
       `<a href="${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}">view</a>`,
-      new Date().toLocaleString("en-US", {
-        timeZone: "UTC",
+      new Date().toLocaleString("en-GB", {
+        day: "numeric",
+        month: "short",
+        year: "numeric",
+        hour: "numeric",
+        minute: "numeric",
         hour12: true,
+        timeZone: "UTC",
       }),
     ],
   ];

--- a/src/main.ts
+++ b/src/main.ts
@@ -98,7 +98,8 @@ function createSummary(inputs: Inputs, steps: Steps): typeof core.summary {
       message(steps.format?.status),
       message(steps.breaking?.status),
       message(steps.lint?.status),
-      `<a href={"${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}">${context.runId}</a>`,
+      `[${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})
+${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
       new Date().toISOString(),
     ],
   ];

--- a/src/main.ts
+++ b/src/main.ts
@@ -232,10 +232,9 @@ async function format(bufPath: string, inputs: Inputs): Promise<Result> {
   if (result.status == Status.Failed && result.stdout.startsWith("diff")) {
     // If the format step fails, parse the diff and write github annotations.
     const diff = parseDiff(result.stdout);
-    result.stdout = ""; // Clear the stdout.
-    console.log("diff", diff);
+    result.stdout = ""; // Clear the stdout to count the number of changes.
     for (const file of diff) {
-      result.stdout += `::error file=${file.to}::Format failed -${file.deletions} +${file.additions} changes.\n`;
+      result.stdout += `::error file=${file.to},title=Buf format::Diff -${file.deletions}/+${file.additions}.\n`;
     }
     console.log(result.stdout);
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -112,17 +112,14 @@ function createSummary(
       }),
     ],
   ];
-  console.log("moduleNames", moduleNames);
   // If push or archive is enabled add a link to the registry.
-  //if (inputs.push) table.push(["push", message(steps.push?.status)]);
-  //if (inputs.archive) table.push(["archive", message(steps.archive?.status)]);
   let output = core.summary.addTable(table);
   if (inputs.push && moduleNames.length > 0) {
     const modules = moduleNames.map(
       (moduleName) =>
         `<a href="https://${moduleName.name}">${moduleName.name}</a>`,
     );
-    output = output.addRaw(`Pushed ${modules.join(", ")} to registry.`, true);
+    output = output.addRaw(`Pushed to ${modules.join(", ")}.`, true);
   }
   if (inputs.archive && moduleNames.length > 0) {
     const modules = moduleNames.map(
@@ -130,7 +127,7 @@ function createSummary(
         `<a href="https://${moduleName.name}">${moduleName.name}</a>`,
     );
     output = output.addRaw(
-      `Archived ${modules.join(", ")} with ${inputs.archive_labels.join(", ")} labels.`,
+      `Archived labels ${inputs.archive_labels.join(", ")} to ${modules.join(", ")}.`,
       true,
     );
   }
@@ -438,12 +435,12 @@ function pass(): Result {
 function message(result: Result | undefined): string {
   switch (result?.status) {
     case Status.Passed:
-      return "✅ passed";
+      return "<code>✅ passed</code>";
     case Status.Failed:
-      return `❌ failed (${result.stdout.split("\n").length - 1})`;
+      return `<code>❌ failed (${result.stdout.split("\n").length - 1})</code>`;
     case Status.Skipped:
-      return "⏩ skipped";
+      return "<code>⏩ skipped</code>";
     default:
-      return "🚫 cancelled";
+      return "<code>🚫 cancelled</code>";
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -229,7 +229,7 @@ async function format(bufPath: string, inputs: Inputs): Promise<Result> {
     args.push("--exclude-path", path);
   }
   const result = await run(bufPath, args);
-  if (result.status == Status.Failed) {
+  if (result.status == Status.Failed && result.stdout.startsWith("diff")) {
     // If the format step fails, parse the diff and write github annotations.
     const diff = parseDiff(result.stdout);
     result.stdout = ""; // Clear the stdout.
@@ -237,6 +237,7 @@ async function format(bufPath: string, inputs: Inputs): Promise<Result> {
     for (const file of diff) {
       result.stdout += `::error file=${file.to}::Format failed -${file.deletions} +${file.additions} changes.\n`;
     }
+    console.log(result.stdout);
   }
   return result;
 }


### PR DESCRIPTION
Update summary comments to better display the status of the checks by including an error count, link to the run, and a last updated time. Update time is useful to ensure that the run reflects the expected results. The format check has been updated to convert `diff` output to GitHub annotations. Table is formatted horizontally to aid readability. There are also links to the BSR for push and archive events.

<img width="740" alt="Screenshot 2024-07-08 at 12 03 19 PM" src="https://github.com/bufbuild/buf-action/assets/3036610/88f2b05e-055a-46d8-a3e9-4faa2a2bd154">

