### PR TITLE
Support duplicate action comments on PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -168,7 +168,7 @@ jobs:
               "❌ failed (1)",
               "⏩ skipped",
             ];
-            const commentTag = "<!-- buf Buf action CI:buf -->";
+            const commentTag = "<!-- buf Buf action CI:test-comment -->";
             const { owner, repo } = context.repo;
             const prNumber = context.payload.pull_request?.number;
             if (!prNumber) {

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -163,12 +163,12 @@ jobs:
         with:
           script: |
             const expects = [
-              "The latest Buf updates on your PR.",
+              "The latest buf updates from workflow Buf action CI, job test-comment.",
               "✅ passed",
               "❌ failed (1)",
               "⏩ skipped",
             ];
-            const commentTag = "<!-- Buf results -->";
+            const commentTag = "<!-- buf Buf action CI:buf -->";
             const { owner, repo } = context.repo;
             const prNumber = context.payload.pull_request?.number;
             if (!prNumber) {

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -163,7 +163,7 @@ jobs:
         with:
           script: |
             const expects = [
-              "The latest buf updates from workflow Buf action CI, job test-comment.",
+              "The latest Buf updates on your PR.",
               "✅ passed",
               "❌ failed (1)",
               "⏩ skipped",

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Add these parameters under the `with` section of the `uses` step in the workflow
 | `paths`                         | Limit to specific files or directories (separated by newlines). | |
 | `exclude_imports`               | Exclude files imported by the target modules. | False |
 | `exclude_paths`                 | Exclude specific files or directories, e.g. "proto/a/a.proto", "proto/a" (separated by newlines). | |
-| `pr_comment`                    | Comment the results on the pull request. The `workflow / job` name must be unique. | Only on pull requests |
+| `pr_comment`                    | Comment the results on the pull request. The workflow and job name combination must be unique. | Only on pull requests |
 | `format`                        | Whether to run the formatting step. | Runs on pushes to Git PR |
 | `lint`                          | Whether to run the linting step. | Runs on pushes to Git PR |
 | `breaking`                      | Whether to run the breaking change detection step. | Runs on pushes to Git PR |

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Add these parameters under the `with` section of the `uses` step in the workflow
 | `paths`                         | Limit to specific files or directories (separated by newlines). | |
 | `exclude_imports`               | Exclude files imported by the target modules. | False |
 | `exclude_paths`                 | Exclude specific files or directories, e.g. "proto/a/a.proto", "proto/a" (separated by newlines). | |
-| `pr_comment`                    | Comment the results on the pull request. | Only on pull requests |
+| `pr_comment`                    | Comment the results on the pull request. The `workflow / job` name must be unique. | Only on pull requests |
 | `format`                        | Whether to run the formatting step. | Runs on pushes to Git PR |
 | `lint`                          | Whether to run the linting step. | Runs on pushes to Git PR |
 | `breaking`                      | Whether to run the breaking change detection step. | Runs on pushes to Git PR |

--- a/action.yml
+++ b/action.yml
@@ -59,7 +59,7 @@ inputs:
     default: "false"
   pr_comment:
     description: |-
-      Comment on the pull request with the results of each step.
+      Comment on the pull request with the results of each step. The workflow and job name combination must be unique.
     required: false
     default: ${{ github.event_name == 'pull_request' }}
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -45761,7 +45761,7 @@ async function main() {
     // Comment on the PR with the summary, if requested.
     if (inputs.pr_comment) {
         const commentID = await findCommentOnPR(lib_github.context, github);
-        await commentOnPR(lib_github.context, github, commentID, `The latest Buf updates on your PR. Results from workflow <a href="${lib_github.context.serverUrl}/${lib_github.context.repo.owner}/${lib_github.context.repo.repo}/actions/runs/${lib_github.context.runId}">${lib_github.context.workflow} / ${lib_github.context.job} (pull request)</a>.\n\n${summary.stringify()}`);
+        await commentOnPR(lib_github.context, github, commentID, `The latest Buf updates on your PR. Results from workflow <a href="${lib_github.context.serverUrl}/${lib_github.context.repo.owner}/${lib_github.context.repo.repo}/actions/runs/${lib_github.context.runId}">${lib_github.context.workflow} / ${lib_github.context.job} (pull_request)</a>.\n\n${summary.stringify()}`);
     }
     // Write the summary to a file defined by GITHUB_STEP_SUMMARY.
     // NB: Write empties the buffer and must be after the comment.

--- a/dist/index.js
+++ b/dist/index.js
@@ -45761,7 +45761,7 @@ async function main() {
     // Comment on the PR with the summary, if requested.
     if (inputs.pr_comment) {
         const commentID = await findCommentOnPR(lib_github.context, github);
-        await commentOnPR(lib_github.context, github, commentID, `The latest Buf updates from ${lib_github.context.job} on your PR.\n\n${summary.stringify()}`);
+        await commentOnPR(lib_github.context, github, commentID, `The latest buf updates from workflow ${lib_github.context.workflow}, job ${lib_github.context.job}.\n\n${summary.stringify()}`);
     }
     // Write the summary to a file defined by GITHUB_STEP_SUMMARY.
     // NB: Write empties the buffer and must be after the comment.

--- a/dist/index.js
+++ b/dist/index.js
@@ -45762,7 +45762,7 @@ async function main() {
     if (inputs.pr_comment) {
         const commentID = await findCommentOnPR(lib_github.context, github);
         await commentOnPR(lib_github.context, github, commentID, `The latest Buf updates to your PR.` +
-            `Results from workflow <a href="${lib_github.context.serverUrl}/${lib_github.context.repo.owner}/${lib_github.context.repo.repo}/actions/runs/${lib_github.context.runId}"><b>${lib_github.context.workflow} / ${lib_github.context} (pull request)</b></a>.` +
+            `Results from workflow <a href="${lib_github.context.serverUrl}/${lib_github.context.repo.owner}/${lib_github.context.repo.repo}/actions/runs/${lib_github.context.runId}"><b>${lib_github.context.workflow} / ${lib_github.context.job} (pull request)</b></a>.` +
             `\n\n${summary.stringify()}`);
     }
     // Write the summary to a file defined by GITHUB_STEP_SUMMARY.

--- a/dist/index.js
+++ b/dist/index.js
@@ -45761,9 +45761,7 @@ async function main() {
     // Comment on the PR with the summary, if requested.
     if (inputs.pr_comment) {
         const commentID = await findCommentOnPR(lib_github.context, github);
-        await commentOnPR(lib_github.context, github, commentID, `The latest Buf updates to your PR.` +
-            `Results from workflow <a href="${lib_github.context.serverUrl}/${lib_github.context.repo.owner}/${lib_github.context.repo.repo}/actions/runs/${lib_github.context.runId}"><b>${lib_github.context.workflow} / ${lib_github.context.job} (pull request)</b></a>.` +
-            `\n\n${summary.stringify()}`);
+        await commentOnPR(lib_github.context, github, commentID, `The latest Buf updates to your PR. Results from workflow <a href="${lib_github.context.serverUrl}/${lib_github.context.repo.owner}/${lib_github.context.repo.repo}/actions/runs/${lib_github.context.runId}">${lib_github.context.workflow} / ${lib_github.context.job} (pull request)</a>.\n\n${summary.stringify()}`);
     }
     // Write the summary to a file defined by GITHUB_STEP_SUMMARY.
     // NB: Write empties the buffer and must be after the comment.

--- a/dist/index.js
+++ b/dist/index.js
@@ -45761,7 +45761,9 @@ async function main() {
     // Comment on the PR with the summary, if requested.
     if (inputs.pr_comment) {
         const commentID = await findCommentOnPR(lib_github.context, github);
-        await commentOnPR(lib_github.context, github, commentID, `The latest buf updates from workflow ${lib_github.context.workflow}, job ${lib_github.context.job}.\n\n${summary.stringify()}`);
+        await commentOnPR(lib_github.context, github, commentID, `The latest Buf updates to your PR.` +
+            `Results from workflow <a href="${lib_github.context.serverUrl}/${lib_github.context.repo.owner}/${lib_github.context.repo.repo}/actions/runs/${lib_github.context.runId}"><b>${lib_github.context.workflow} / ${lib_github.context} (pull request)</b></a>.` +
+            `\n\n${summary.stringify()}`);
     }
     // Write the summary to a file defined by GITHUB_STEP_SUMMARY.
     // NB: Write empties the buffer and must be after the comment.
@@ -45785,7 +45787,6 @@ function createSummary(inputs, steps, moduleNames) {
             { data: "Format", header: true },
             { data: "Lint", header: true },
             { data: "Breaking", header: true },
-            { data: "Run", header: true },
             { data: "Updated (UTC)", header: true },
         ],
         [
@@ -45793,7 +45794,6 @@ function createSummary(inputs, steps, moduleNames) {
             message(steps.format),
             message(steps.lint),
             message(steps.breaking),
-            `<a href="${lib_github.context.serverUrl}/${lib_github.context.repo.owner}/${lib_github.context.repo.repo}/actions/runs/${lib_github.context.runId}">view</a>`,
             new Date().toLocaleString("en-US", {
                 day: "numeric",
                 month: "short",

--- a/dist/index.js
+++ b/dist/index.js
@@ -45761,7 +45761,7 @@ async function main() {
     // Comment on the PR with the summary, if requested.
     if (inputs.pr_comment) {
         const commentID = await findCommentOnPR(lib_github.context, github);
-        await commentOnPR(lib_github.context, github, commentID, `The latest Buf updates to your PR. Results from workflow <a href="${lib_github.context.serverUrl}/${lib_github.context.repo.owner}/${lib_github.context.repo.repo}/actions/runs/${lib_github.context.runId}">${lib_github.context.workflow} / ${lib_github.context.job} (pull request)</a>.\n\n${summary.stringify()}`);
+        await commentOnPR(lib_github.context, github, commentID, `The latest Buf updates on your PR. Results from workflow <a href="${lib_github.context.serverUrl}/${lib_github.context.repo.owner}/${lib_github.context.repo.repo}/actions/runs/${lib_github.context.runId}">${lib_github.context.workflow} / ${lib_github.context.job} (pull request)</a>.\n\n${summary.stringify()}`);
     }
     // Write the summary to a file defined by GITHUB_STEP_SUMMARY.
     // NB: Write empties the buffer and must be after the comment.

--- a/src/comment.ts
+++ b/src/comment.ts
@@ -13,12 +13,15 @@
 // limitations under the License.
 
 import * as core from "@actions/core";
+import { context } from "@actions/github";
 import { Context } from "@actions/github/lib/context";
 import { GitHub } from "@actions/github/lib/utils";
 
-// commentTag is the tag used to identify the comment. This is a non-visible
-// string injected into the comment body.
-const commentTag = "<!-- Buf results -->";
+// commentTag returns the tag used to identify the comment. This is a non-visible
+// string injected into the comment body. It is unique to the workflow and job.
+function commentTag(): string {
+  return `<!-- buf ${context.workflow}:${context.job} -->`;
+}
 
 // findCommentOnPR finds the comment on the PR that contains the Buf results.
 // If the comment is found, it returns the comment ID. If the comment is not
@@ -39,7 +42,7 @@ export async function findCommentOnPR(
     issue_number: prNumber,
   });
   const previousComment = comments.find((comment) =>
-    comment.body?.includes(commentTag),
+    comment.body?.includes(commentTag()),
   );
   if (previousComment) {
     core.info(`Found previous comment ${previousComment.id}`);
@@ -66,7 +69,7 @@ export async function commentOnPR(
   const content = {
     owner: owner,
     repo: repo,
-    body: body + commentTag,
+    body: body + commentTag(),
   };
   if (commentID) {
     await github.rest.issues.updateComment({

--- a/src/main.ts
+++ b/src/main.ts
@@ -56,7 +56,9 @@ async function main() {
       context,
       github,
       commentID,
-      `The latest buf updates from workflow ${context.workflow}, job ${context.job}.\n\n${summary.stringify()}`,
+      `The latest Buf updates to your PR.` +
+        `Results from workflow <a href="${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}"><b>${context.workflow} / ${context} (pull request)</b></a>.` +
+        `\n\n${summary.stringify()}`,
     );
   }
   // Write the summary to a file defined by GITHUB_STEP_SUMMARY.
@@ -101,7 +103,6 @@ function createSummary(
       { data: "Format", header: true },
       { data: "Lint", header: true },
       { data: "Breaking", header: true },
-      { data: "Run", header: true },
       { data: "Updated (UTC)", header: true },
     ],
     [
@@ -109,7 +110,6 @@ function createSummary(
       message(steps.format),
       message(steps.lint),
       message(steps.breaking),
-      `<a href="${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}">view</a>`,
       new Date().toLocaleString("en-US", {
         day: "numeric",
         month: "short",

--- a/src/main.ts
+++ b/src/main.ts
@@ -56,9 +56,7 @@ async function main() {
       context,
       github,
       commentID,
-      `The latest Buf updates to your PR.` +
-        `Results from workflow <a href="${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}"><b>${context.workflow} / ${context.job} (pull request)</b></a>.` +
-        `\n\n${summary.stringify()}`,
+      `The latest Buf updates to your PR. Results from workflow <a href="${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}">${context.workflow} / ${context.job} (pull request)</a>.\n\n${summary.stringify()}`,
     );
   }
   // Write the summary to a file defined by GITHUB_STEP_SUMMARY.

--- a/src/main.ts
+++ b/src/main.ts
@@ -56,7 +56,7 @@ async function main() {
       context,
       github,
       commentID,
-      `The latest Buf updates on your PR.\n\n${summary.stringify()}`,
+      `The latest Buf updates from ${context.job} on your PR.\n\n${summary.stringify()}`,
     );
   }
   // Write the summary to a file defined by GITHUB_STEP_SUMMARY.

--- a/src/main.ts
+++ b/src/main.ts
@@ -56,7 +56,7 @@ async function main() {
       context,
       github,
       commentID,
-      `The latest Buf updates from ${context.job} on your PR.\n\n${summary.stringify()}`,
+      `The latest buf updates from workflow ${context.workflow}, job ${context.job}.\n\n${summary.stringify()}`,
     );
   }
   // Write the summary to a file defined by GITHUB_STEP_SUMMARY.

--- a/src/main.ts
+++ b/src/main.ts
@@ -57,7 +57,7 @@ async function main() {
       github,
       commentID,
       `The latest Buf updates to your PR.` +
-        `Results from workflow <a href="${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}"><b>${context.workflow} / ${context} (pull request)</b></a>.` +
+        `Results from workflow <a href="${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}"><b>${context.workflow} / ${context.job} (pull request)</b></a>.` +
         `\n\n${summary.stringify()}`,
     );
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -56,7 +56,7 @@ async function main() {
       context,
       github,
       commentID,
-      `The latest Buf updates on your PR. Results from workflow <a href="${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}">${context.workflow} / ${context.job} (pull request)</a>.\n\n${summary.stringify()}`,
+      `The latest Buf updates on your PR. Results from workflow <a href="${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}">${context.workflow} / ${context.job} (pull_request)</a>.\n\n${summary.stringify()}`,
     );
   }
   // Write the summary to a file defined by GITHUB_STEP_SUMMARY.

--- a/src/main.ts
+++ b/src/main.ts
@@ -56,7 +56,7 @@ async function main() {
       context,
       github,
       commentID,
-      `The latest Buf updates to your PR. Results from workflow <a href="${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}">${context.workflow} / ${context.job} (pull request)</a>.\n\n${summary.stringify()}`,
+      `The latest Buf updates on your PR. Results from workflow <a href="${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}">${context.workflow} / ${context.job} (pull request)</a>.\n\n${summary.stringify()}`,
     );
   }
   // Write the summary to a file defined by GITHUB_STEP_SUMMARY.


### PR DESCRIPTION
The action may be run multiple times as requested. This isn't supported by the PR comment status update as it presumes a single run of a v2 style workspace. To support this case we now dedupe comments on workflow and job name. The `view` link is moved to a `<workflow> / <job> (pull_request)` link in the comment description to help users differentiate runs. The name matches the status name below the CI fold. Note: there is no step level ID provided to the action so each invocation must be unique combination of workflow and job name otherwise the comment will update a previous comment.

<img width="738" alt="Screenshot 2024-07-18 at 9 40 35 PM" src="https://github.com/user-attachments/assets/5f62342d-59f3-4be6-a6e6-eb139d10a2f3">

Fixes #51