### PR TITLE
Fix new comment tags to overwrite old comments

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -45608,6 +45608,9 @@ async function downloadBuf(version) {
 // limitations under the License.
 
 
+// oldCommentTag is the previous tag used to identify the comment. This is
+// temporary and will be removed in a future release.
+const oldCommentTag = "<!-- Buf results -->";
 // commentTag returns the tag used to identify the comment. This is a non-visible
 // string injected into the comment body. It is unique to the workflow and job.
 function commentTag() {
@@ -45628,7 +45631,10 @@ async function findCommentOnPR(context, github) {
         repo: repo,
         issue_number: prNumber,
     });
-    const previousComment = comments.find((comment) => comment.body?.includes(commentTag()));
+    const tag = commentTag();
+    const previousComment = comments.find((comment) => 
+    // TODO: Remove the old comment tag check in a future release.
+    comment.body?.includes(tag) || comment.body?.includes(oldCommentTag));
     if (previousComment) {
         core.info(`Found previous comment ${previousComment.id}`);
         return previousComment.id;

--- a/src/comment.ts
+++ b/src/comment.ts
@@ -17,6 +17,10 @@ import { context } from "@actions/github";
 import { Context } from "@actions/github/lib/context";
 import { GitHub } from "@actions/github/lib/utils";
 
+// oldCommentTag is the previous tag used to identify the comment. This is
+// temporary and will be removed in a future release.
+const oldCommentTag = "<!-- Buf results -->";
+
 // commentTag returns the tag used to identify the comment. This is a non-visible
 // string injected into the comment body. It is unique to the workflow and job.
 function commentTag(): string {
@@ -41,8 +45,11 @@ export async function findCommentOnPR(
     repo: repo,
     issue_number: prNumber,
   });
-  const previousComment = comments.find((comment) =>
-    comment.body?.includes(commentTag()),
+  const tag = commentTag();
+  const previousComment = comments.find(
+    (comment) =>
+      // TODO: Remove the old comment tag check in a future release.
+      comment.body?.includes(tag) || comment.body?.includes(oldCommentTag),
   );
   if (previousComment) {
     core.info(`Found previous comment ${previousComment.id}`);


### PR DESCRIPTION
For a better migration story ensure the old style comment tags are captured to avoid stale comments on PRs. The action will now convert the comments from the previous style to the new comment tag. This may cause temporary failures for comments with multiple runs, but those cases just need to be re-run to correct the state.