### PR TITLE
Check input for empty directories

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,6 +79,20 @@ jobs:
         with:
           setup_only: true
       - run: buf --version | grep $BUF_VERSION
+  test-empty-build:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./
+        with:
+          lint: false
+          format: false
+          breaking: false
+          push: false
+          archive: false
+          pr_comment: false
+        continue-on-error: true # build fails
   test-lint:
     runs-on: ubuntu-latest
     needs: build

--- a/README.md
+++ b/README.md
@@ -32,10 +32,8 @@ jobs:
   buf:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Run Buf
-        uses: bufbuild/buf-action@v1
+      - uses: actions/checkout@v4
+      - uses: bufbuild/buf-action@v1
         with:
           token: ${{ secrets.BUF_TOKEN }}
 ```

--- a/README.md
+++ b/README.md
@@ -32,8 +32,10 @@ jobs:
   buf:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: bufbuild/buf-action@v1
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Run Buf
+        uses: bufbuild/buf-action@v1
         with:
           token: ${{ secrets.BUF_TOKEN }}
 ```

--- a/dist/index.js
+++ b/dist/index.js
@@ -45829,8 +45829,7 @@ async function runWorkflow(bufPath, inputs, moduleNames) {
     steps.build = await build(bufPath, inputs);
     if (steps.build.status == Status.Failed) {
         if (steps.build.stderr.match(/had no .proto files/)) {
-            core.info("Empty repository detected, ensure the repository is checked out");
-            return steps;
+            core.info('Did you forget to add the "actions/checkout@v4" checkout step to your workflow?');
         }
         return steps;
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -45828,6 +45828,10 @@ async function runWorkflow(bufPath, inputs, moduleNames) {
     const steps = {};
     steps.build = await build(bufPath, inputs);
     if (steps.build.status == Status.Failed) {
+        if (steps.build.stderr.match(/had no .proto files/)) {
+            core.info("Empty repository detected, ensure the repository is checked out");
+            return steps;
+        }
         return steps;
     }
     const checks = await Promise.all([

--- a/src/main.ts
+++ b/src/main.ts
@@ -155,9 +155,8 @@ async function runWorkflow(
   if (steps.build.status == Status.Failed) {
     if (steps.build.stderr.match(/had no .proto files/)) {
       core.info(
-        "Empty repository detected, ensure the repository is checked out",
+        'Did you forget to add the "actions/checkout@v4" checkout step to your workflow?',
       );
-      return steps;
     }
     return steps;
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -153,6 +153,12 @@ async function runWorkflow(
   const steps: Steps = {};
   steps.build = await build(bufPath, inputs);
   if (steps.build.status == Status.Failed) {
+    if (steps.build.stderr.match(/had no .proto files/)) {
+      core.info(
+        "Empty repository detected, ensure the repository is checked out",
+      );
+      return steps;
+    }
     return steps;
   }
   const checks = await Promise.all([


### PR DESCRIPTION
To provide better errors we can map some of the buf errors to config issue errors. It's easy to miss the `- uses: actions/checkout@v4`  step, provide an annotation to help resolve issues. This adds an info log:
```diff
/opt/hostedtoolcache/buf/1.35.0/x64/buf build --error-format github-actions
Failure: "." had no .proto files
+Did you forget to add the "actions/checkout@v4" checkout step to your workflow?
Error: Failed build
```