### PR TITLE
Disable PR comment by default from forks

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,14 +67,14 @@ Add these parameters under the `with` section of the `uses` step in the workflow
 | `paths`                         | Limit to specific files or directories (separated by newlines). | |
 | `exclude_imports`               | Exclude files imported by the target modules. | False |
 | `exclude_paths`                 | Exclude specific files or directories, e.g. "proto/a/a.proto", "proto/a" (separated by newlines). | |
-| `pr_comment`                    | Comment the results on the pull request. The workflow and job name combination must be unique. | Only on pull requests |
+| `pr_comment`                    | Comment the results on the pull request. The workflow and job name combination must be unique. | Only on pull requests (non forks) |
 | `format`                        | Whether to run the formatting step. | Runs on pushes to Git PR |
 | `lint`                          | Whether to run the linting step. | Runs on pushes to Git PR |
 | `breaking`                      | Whether to run the breaking change detection step. | Runs on pushes to Git PR |
 | `breaking_against`              | [Input](https://buf.build/docs/reference/inputs) to compare against. | Base of the PR or the commit before the event |
-| `push`                          | Whether to run the push step. | Runs on Git pushes |
+| `push`                          | Whether to run the push step. | Runs on Git pushes (non forks) |
 | `push_disable_create`           | Disables repository creation if it does not exist. | False |
-| `archive`                       | Whether to run the archive step. | Runs on Git deletes |
+| `archive`                       | Whether to run the archive step. | Runs on Git deletes (non forks) |
 | `setup_only`                    | Setup only the `buf` environment, optionally logging into the BSR, but without executing other commands. | |
 | `github_actor`                  | GitHub actor for API requests. | Actor from GitHub context |
 | `github_token`                  | GitHub token for API requests. Ensures requests aren't rate limited | Token from GitHub context |

--- a/action.yml
+++ b/action.yml
@@ -56,7 +56,7 @@ inputs:
   pr_comment:
     description: |-
       Comment on the pull request with the results of each step. The workflow and job name combination must be unique.
-      Only runs on pull requests from non forked repositories.
+      Only runs on pull requests, for non forked repositories.
     required: false
     default: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
 
@@ -118,7 +118,7 @@ inputs:
     description: |-
       Whether to run the push step. Runs by default on pushes, for non forked repositories.
     required: false
-    default: ${{ github.event_name == 'push' && github.event.pull_request.head.repo.full_name == github.repository }}
+    default: ${{ github.event_name == 'push' }}
   push_disable_create:
     description: |-
       Disables repository creation if it does not exist. Defaults to false.
@@ -129,7 +129,7 @@ inputs:
     description: |-
       Whether to run the archive step. Runs by default on deletes, for non forked repositories.
     required: false
-    default: ${{ github.event_name == 'delete' && github.event.pull_request.head.repo.full_name == github.repository }}
+    default: ${{ github.event_name == 'delete' }}
 
 outputs:
   buf_version:

--- a/action.yml
+++ b/action.yml
@@ -56,8 +56,9 @@ inputs:
   pr_comment:
     description: |-
       Comment on the pull request with the results of each step. The workflow and job name combination must be unique.
+      Only runs on pull requests from non forked repositories.
     required: false
-    default: ${{ github.event_name == 'pull_request' }}
+    default: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
 
   input:
     description: |-

--- a/action.yml
+++ b/action.yml
@@ -116,9 +116,9 @@ inputs:
 
   push:
     description: |-
-      Whether to run the push step. Runs by default on pushes.
+      Whether to run the push step. Runs by default on pushes, for non forked repositories.
     required: false
-    default: ${{ github.event_name == 'push' }}
+    default: ${{ github.event_name == 'push' && github.event.pull_request.head.repo.full_name == github.repository }}
   push_disable_create:
     description: |-
       Disables repository creation if it does not exist. Defaults to false.
@@ -127,9 +127,9 @@ inputs:
 
   archive:
     description: |-
-      Whether to run the archive step. Runs by default on deletes.
+      Whether to run the archive step. Runs by default on deletes, for non forked repositories.
     required: false
-    default: ${{ github.event_name == 'delete' }}
+    default: ${{ github.event_name == 'delete' && github.event.pull_request.head.repo.full_name == github.repository }}
 
 outputs:
   buf_version:


### PR DESCRIPTION
Forked PRs can fail to access the secrets for the repository. This can fail on trying to comment the results from CI on the PR. Disable comments for all forked by default.

Tested here on a forked https://github.com/emcfarlane/releases/pull/14 and unforked https://github.com/emcfarlane/releases/pull/15 change. The update before reference buf-action@main, then updating to buf-action@ed/disableForkComment the forked comment now disables the comment, whilst the unforked still comments.