### PR TITLE
Prepare for v1.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "buf-action",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "buf-action",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@actions/core": "^1.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "buf-action",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "GitHub Action for buf",
   "main": "src/main.ts",
   "scripts": {


### PR DESCRIPTION
Releases the changes in https://github.com/bufbuild/buf-action/pull/64 to fix failures in CI for contributors PRs.