### PR TITLE
Allow overriding Buf version in PATH

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -45508,14 +45508,11 @@ async function installBuf(github, versionInput) {
             silent: true,
         });
         const version = bufVersion.stdout.trim();
-        core.info(`Using buf (${version}) found in $PATH`);
-        if (!semver.satisfies(version, requiredVersion)) {
-            throw new Error(`The version of buf (${version}) does not satisfy the required version (${requiredVersion})`);
+        if (semver.satisfies(version, requiredVersion) &&
+            (resolvedVersion == "" || semver.eq(version, resolvedVersion))) {
+            core.info(`Using buf (${version}) found in $PATH`);
+            return [binName, version];
         }
-        if (resolvedVersion != "" && !semver.eq(version, resolvedVersion)) {
-            throw new Error(`The version of buf (${version}) does not equal the resolved version (${resolvedVersion})`);
-        }
-        return [binName, version];
     }
     if (resolvedVersion === "") {
         resolvedVersion = await latestVersion(github);

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -46,18 +46,13 @@ export async function installBuf(
       silent: true,
     });
     const version = bufVersion.stdout.trim();
-    core.info(`Using buf (${version}) found in $PATH`);
-    if (!semver.satisfies(version, requiredVersion)) {
-      throw new Error(
-        `The version of buf (${version}) does not satisfy the required version (${requiredVersion})`,
-      );
+    if (
+      semver.satisfies(version, requiredVersion) &&
+      (resolvedVersion == "" || semver.eq(version, resolvedVersion))
+    ) {
+      core.info(`Using buf (${version}) found in $PATH`);
+      return [binName, version];
     }
-    if (resolvedVersion != "" && !semver.eq(version, resolvedVersion)) {
-      throw new Error(
-        `The version of buf (${version}) does not equal the resolved version (${resolvedVersion})`,
-      );
-    }
-    return [binName, version];
   }
   if (resolvedVersion === "") {
     resolvedVersion = await latestVersion(github);


### PR DESCRIPTION
This avoids requiring the version of Buf found in the PATH to match the resolved. Fallback to installing a new explicit version in the toolcache.

Fixes #71 