### PR TITLE
Set debug when the action is using debug logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,12 @@ we recommend migrating to this consolidated action that has additional capabilit
 
 See the [migration guide](MIGRATION.md) for more information.
 
+## Debugging
+
+To debug the action, rerun the workflow with debug logging enabled.
+This will run all buf commands with the `--debug` flag.
+See the [re-run jobs with debug logging](https://github.blog/changelog/2022-05-24-github-actions-re-run-jobs-with-debug-logging/) for more information.
+
 ## Feedback and support
 
 If you have any feedback or need support, please reach out to us on the [Buf Slack][slack],

--- a/dist/index.js
+++ b/dist/index.js
@@ -45881,9 +45881,6 @@ async function lint(bufPath, inputs) {
         return skip();
     }
     const args = ["lint", "--error-format", "github-actions"];
-    if (core.isDebug()) {
-        args.push("--debug");
-    }
     if (inputs.input) {
         args.push(inputs.input);
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -45881,6 +45881,9 @@ async function lint(bufPath, inputs) {
         return skip();
     }
     const args = ["lint", "--error-format", "github-actions"];
+    if (core.isDebug()) {
+        args.push("--debug");
+    }
     if (inputs.input) {
         args.push(inputs.input);
     }
@@ -46049,6 +46052,9 @@ var Status;
 })(Status || (Status = {}));
 // run executes the buf command with the given arguments.
 async function run(bufPath, args) {
+    if (core.isDebug()) {
+        args = ["--debug", ...args];
+    }
     return exec.getExecOutput(bufPath, args, {
         ignoreReturnCode: true,
         env: {

--- a/src/main.ts
+++ b/src/main.ts
@@ -214,9 +214,6 @@ async function lint(bufPath: string, inputs: Inputs): Promise<Result> {
     return skip();
   }
   const args = ["lint", "--error-format", "github-actions"];
-  if (core.isDebug()) {
-    args.push("--debug");
-  }
   if (inputs.input) {
     args.push(inputs.input);
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -214,6 +214,9 @@ async function lint(bufPath: string, inputs: Inputs): Promise<Result> {
     return skip();
   }
   const args = ["lint", "--error-format", "github-actions"];
+  if (core.isDebug()) {
+    args.push("--debug");
+  }
   if (inputs.input) {
     args.push(inputs.input);
   }
@@ -405,6 +408,9 @@ interface Result extends exec.ExecOutput {
 
 // run executes the buf command with the given arguments.
 async function run(bufPath: string, args: string[]): Promise<Result> {
+  if (core.isDebug()) {
+    args = ["--debug", ...args];
+  }
   return exec
     .getExecOutput(bufPath, args, {
       ignoreReturnCode: true,


### PR DESCRIPTION
Inherits the debug condition from the action to enable running of commands with `--debug` flag set. This is preferred over an explicit `debug` parameter to avoid churn in changing the config. 

Closes #77