### PR TITLE
Set --source-control-url on push

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -45963,6 +45963,9 @@ async function push(bufPath, inputs, moduleNames) {
         core.debug("Skipping push, no named modules detected");
         return skip();
     }
+    // We want push to succeed without additional user configuration even if the action is being run on an
+    // enterprise GitHub instance. Because enterprise GitHub instances can have an arbitrary URL, the Buf CLI with not be
+    // able to automatically detect the source control url, so we set it explicitly.
     const sourceControlUrl = `${lib_github.context.serverUrl}/${lib_github.context.repo.owner}/${lib_github.context.repo.repo}/commit/${lib_github.context.sha}`;
     const args = [
         "push",

--- a/dist/index.js
+++ b/dist/index.js
@@ -45963,12 +45963,15 @@ async function push(bufPath, inputs, moduleNames) {
         core.debug("Skipping push, no named modules detected");
         return skip();
     }
+    const sourceControlUrl = `${lib_github.context.serverUrl}/${lib_github.context.repo.owner}/${lib_github.context.repo.repo}/commit/${lib_github.context.sha}`;
     const args = [
         "push",
         "--error-format",
         "github-actions",
         "--exclude-unnamed",
         "--git-metadata",
+        "--source-control-url",
+        sourceControlUrl,
     ];
     if (!inputs.push_disable_create) {
         args.push("--create");

--- a/src/main.ts
+++ b/src/main.ts
@@ -303,12 +303,18 @@ async function push(
     core.debug("Skipping push, no named modules detected");
     return skip();
   }
+  // We want push to succeed without additional user configuration even if the action is being run on an
+  // enterprise GitHub instance. Because enterprise GitHub instances can have an arbitrary URL, the Buf CLI with not be
+  // able to automatically detect the source control url, so we set it explicitly. 
+  const sourceControlUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/commit/${context.sha}`;
   const args = [
     "push",
     "--error-format",
     "github-actions",
     "--exclude-unnamed",
     "--git-metadata",
+    "--source-control-url",
+    sourceControlUrl,
   ];
   if (!inputs.push_disable_create) {
     args.push("--create");

--- a/src/main.ts
+++ b/src/main.ts
@@ -305,7 +305,7 @@ async function push(
   }
   // We want push to succeed without additional user configuration even if the action is being run on an
   // enterprise GitHub instance. Because enterprise GitHub instances can have an arbitrary URL, the Buf CLI with not be
-  // able to automatically detect the source control url, so we set it explicitly. 
+  // able to automatically detect the source control url, so we set it explicitly.
   const sourceControlUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/commit/${context.sha}`;
   const args = [
     "push",


### PR DESCRIPTION
This ensures push will work on enterprise GitHub instances that have arbitrary URLs.