### PR TITLE
Rebuild on dependabot updates

### DIFF
--- a/.github/workflows/dependabot.yaml
+++ b/.github/workflows/dependabot.yaml
@@ -1,0 +1,22 @@
+name: Dependabot Update
+on:
+  pull_request:
+    types: [opened, synchronize]
+permissions:
+  contents: write
+  pull-requests: read
+jobs:
+  build:
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: rebuild
+        run: |
+          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY
+          make build
+          git add -A
+          git commit -m "Build"
+          git push -u origin HEAD:${{ github.event.pull_request.head.ref }}


### PR DESCRIPTION
To allow dependabot to upgrade deps, run an action to rebuild after the package updates. Based on https://github.com/dependabot/dependabot-core/issues/5962#issuecomment-1303781931