### PR TITLE
Prepare for v1.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "buf-action",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "buf-action",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@actions/core": "^1.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "buf-action",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "GitHub Action for buf",
   "main": "src/main.ts",
   "scripts": {


### PR DESCRIPTION
Below is the draft release notes:

## What's Changed
* Add migration guide doc by @emcfarlane in https://github.com/bufbuild/buf-action/pull/74
* Set --debug when the action is using debug logging by @emcfarlane in https://github.com/bufbuild/buf-action/pull/78
* Set --source-control-url on push so that the push action now works by default on enterprise GitHub instances by @nicksnyder in https://github.com/bufbuild/buf-action/pull/86

## New Contributors
* @doriable made their first contribution in https://github.com/bufbuild/buf-action/pull/98

**Full Changelog**: https://github.com/bufbuild/buf-action/compare/v1.0.2...v1.0.3