### PR TITLE
Add environment variable authentication docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,15 +126,24 @@ If no version is specified in the workflow config, the action will resolve the v
 way for consumers of your APIs to generate code.
 Authenticating with the BSR is required for both the push and archive label steps.
 
-To authenticate with the BSR, set the API token as the parameter `token`.
 Generate a token from the [BSR UI](https://buf.build/docs/bsr/authentication#create-an-api-token) and add it to the [repository secrets](https://docs.github.com/en/actions/reference/encrypted-secrets).
+Add the secret to the workflow file as the `token` parameter:
 
 ```yaml
 - uses: bufbuild/buf-action@v1
   with:
     token: ${{ secrets.BUF_TOKEN }}
 ```
+Or set the token as an environment variable:
 
+```yaml
+- env:
+    BUF_TOKEN: ${{ secrets.BUF_TOKEN }}
+- uses: bufbuild/buf-action@v1
+```
+
+Setting the token as an environment variable avoids calling `buf registry login`.
+The login command will store the token in the `.netrc` file in the home directory of the runner.
 For more information on authentication, see the [BSR Authentication Reference](https://buf.build/docs/bsr/authentication).
 
 ### Summary comment

--- a/examples/auth-env/buf-ci.yaml
+++ b/examples/auth-env/buf-ci.yaml
@@ -1,0 +1,17 @@
+name: Buf CI
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+  delete:
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  buf:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - env:
+          BUF_TOKEN: ${{ secrets.BUF_TOKEN }}
+      - uses: bufbuild/buf-action@v1


### PR DESCRIPTION
This improves the authentication docs for use of environment variable tokens. For enterprise runners, where the state between the runners is shared, this is an importent detail to avoid exposing the buf token to other actions.