### PR TITLE
Fix CI comment test for dependabot

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -147,7 +147,8 @@ jobs:
           pr_comment: false
   test-comment:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    # Only run on pull requests from the same repository, comments from forks are not tested. Dependabot is skipped.
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
     needs: 
       - test-lint
       - test-format


### PR DESCRIPTION
Skips testing of comments for dependabot. The action will skip writing of comments when the dependabot actor is detected.