### PR TITLE
Fix latest version resolution for GitHub enterprise

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -50,7 +50,7 @@ inputs:
     default: ${{ github.token }}
   public_github_token:
     description: |-
-      GitHub token for github.com. Required to be set when running on a private GitHub Enterprise instance, and ignored otherwise.
+      GitHub token for github.com. Must be set when running on a private GitHub Enterprise instance to authenticate requests, otherwise ignored.
   setup_only:
     description: |-
       Setup only the buf environment, optionally logging into the BSR, but without executing other commands.

--- a/action.yml
+++ b/action.yml
@@ -45,12 +45,12 @@ inputs:
     default: ${{ github.actor }}
   github_token:
     description: |-
-      GitHub token for API requests.
+      GitHub token for the GitHub instance this action is running on.
     required: false
     default: ${{ github.token }}
   public_github_token:
     description: |-
-      GitHub token for the public github.com, for use with enterprise GitHub instances.
+      GitHub token for github.com. Required to be set when running on a private GitHub Enterprise instance, and ignored otherwise.
   setup_only:
     description: |-
       Setup only the buf environment, optionally logging into the BSR, but without executing other commands.

--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,9 @@ inputs:
       GitHub token for API requests.
     required: false
     default: ${{ github.token }}
+  public_github_token:
+    description: |-
+      GitHub token for the public github.com, for use with enterprise GitHub instances.
   setup_only:
     description: |-
       Setup only the buf environment, optionally logging into the BSR, but without executing other commands.

--- a/dist/index.js
+++ b/dist/index.js
@@ -48089,6 +48089,8 @@ const publicGitHubApiUrl = "https://api.github.com";
 async function main() {
     const inputs = getInputs();
     const github = (0,lib_github.getOctokit)(inputs.github_token);
+    // Check if the action is running on a GitHub Enterprise instance.
+    // If so, use the public GitHub API for resolving the Buf version etc.
     let publicGithubToken = inputs.github_token;
     let publicGithub = github;
     const apiUrl = process.env.GITHUB_API_URL || ``;
@@ -48099,7 +48101,9 @@ async function main() {
             // Warn if the public GitHub token is not set. Don't fail as not required.
             core.warning("public_github_token not set, GitHub API requests may be limited");
         }
-        publicGithub = (0,lib_github.getOctokit)(publicGithubToken, { baseUrl: publicGitHubApiUrl });
+        publicGithub = (0,lib_github.getOctokit)(publicGithubToken, {
+            baseUrl: publicGitHubApiUrl,
+        });
     }
     const [bufPath, bufVersion] = await installBuf(publicGithub, publicGithubToken, inputs.version);
     core.setOutput(Outputs.BufVersion, bufVersion);

--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -31862,6 +31862,7 @@ function getInputs() {
         pr_comment: core.getBooleanInput("pr_comment"),
         github_actor: core.getInput("github_actor"),
         github_token: core.getInput("github_token"),
+        public_github_token: core.getInput("public_github_token"),
         // Inputs shared between buf steps.
         input: core.getInput("input"),
         paths: core.getMultilineInput("paths"),

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -29,6 +29,7 @@ export interface Inputs {
   pr_comment: boolean;
   github_actor: string;
   github_token: string;
+  public_github_token: string;
 
   input: string;
   paths: string[];
@@ -55,6 +56,7 @@ export function getInputs(): Inputs {
     pr_comment: core.getBooleanInput("pr_comment"),
     github_actor: core.getInput("github_actor"),
     github_token: core.getInput("github_token"),
+    public_github_token: core.getInput("public_github_token"),
     // Inputs shared between buf steps.
     input: core.getInput("input"),
     paths: core.getMultilineInput("paths"),

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -119,7 +119,10 @@ type platformTable = {
 };
 
 // downloadBuf downloads the buf binary and returns the path to the binary.
-async function downloadBuf(version: string, githubToken: string): Promise<string> {
+async function downloadBuf(
+  version: string,
+  githubToken: string,
+): Promise<string> {
   const table: platformTable = {
     darwin: {
       x64: "buf-Darwin-x86_64",

--- a/src/main.ts
+++ b/src/main.ts
@@ -37,19 +37,19 @@ const publicGitHubApiUrl = "https://api.github.com";
 async function main() {
   const inputs = getInputs();
   const github = getOctokit(inputs.github_token);
-  let publicGitHubToken = inputs.github_token;
-  let publicGitHub = github;
-  const apiUrl = github.request.defaults.baseUrl || process.env.GITHUB_API_URL || ``;
+  let publicGithubToken = inputs.github_token;
+  let publicGithub = github;
+  const apiUrl = process.env.GITHUB_API_URL || ``;
   if (!apiUrl.startsWith(publicGitHubApiUrl)) {
     core.info("Running on GitHub Enterprise, using public GitHub API.");
-    publicGitHubToken = inputs.public_github_token;
-    if (publicGitHubToken == "") {
+    publicGithubToken = inputs.public_github_token;
+    if (publicGithubToken == "") {
       // Warn if the public GitHub token is not set. Don't fail as not required.
       core.warning("public_github_token not set, GitHub API requests may be limited");
     }
-    publicGitHub = getOctokit(inputs.public_github_token, { baseUrl: publicGitHubApiUrl });
+    publicGithub = getOctokit(publicGithubToken, { baseUrl: publicGitHubApiUrl });
   }
-  const [bufPath, bufVersion] = await installBuf(publicGitHub, publicGitHubToken, inputs.version);
+  const [bufPath, bufVersion] = await installBuf(publicGithub, publicGithubToken, inputs.version);
   core.setOutput(Outputs.BufVersion, bufVersion);
   core.setOutput(Outputs.BufPath, bufPath);
   core.saveState(Outputs.BufPath, bufPath);

--- a/src/main.ts
+++ b/src/main.ts
@@ -37,6 +37,8 @@ const publicGitHubApiUrl = "https://api.github.com";
 async function main() {
   const inputs = getInputs();
   const github = getOctokit(inputs.github_token);
+  // Check if the action is running on a GitHub Enterprise instance.
+  // If so, use the public GitHub API for resolving the Buf version etc.
   let publicGithubToken = inputs.github_token;
   let publicGithub = github;
   const apiUrl = process.env.GITHUB_API_URL || ``;
@@ -45,11 +47,19 @@ async function main() {
     publicGithubToken = inputs.public_github_token;
     if (publicGithubToken == "") {
       // Warn if the public GitHub token is not set. Don't fail as not required.
-      core.warning("public_github_token not set, GitHub API requests may be limited");
+      core.warning(
+        "public_github_token not set, GitHub API requests may be limited",
+      );
     }
-    publicGithub = getOctokit(publicGithubToken, { baseUrl: publicGitHubApiUrl });
+    publicGithub = getOctokit(publicGithubToken, {
+      baseUrl: publicGitHubApiUrl,
+    });
   }
-  const [bufPath, bufVersion] = await installBuf(publicGithub, publicGithubToken, inputs.version);
+  const [bufPath, bufVersion] = await installBuf(
+    publicGithub,
+    publicGithubToken,
+    inputs.version,
+  );
   core.setOutput(Outputs.BufVersion, bufVersion);
   core.setOutput(Outputs.BufPath, bufPath);
   core.saveState(Outputs.BufPath, bufPath);

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,7 +34,7 @@ import { parseModuleNames, ModuleName } from "./config";
 async function main() {
   const inputs = getInputs();
   const github = getOctokit(inputs.github_token);
-  const [bufPath, bufVersion] = await installBuf(github, inputs.version);
+  const [bufPath, bufVersion] = await installBuf(github, inputs);
   core.setOutput(Outputs.BufVersion, bufVersion);
   core.setOutput(Outputs.BufPath, bufPath);
   core.saveState(Outputs.BufPath, bufPath);


### PR DESCRIPTION
This fixes the version resolution on enterprise instances by ensuing the API call is always resolved to the public GitHub instance.

Fixes #129 