### PR TITLE
Prepare for v1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "buf-action",
-  "version": "1.1.1",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "buf-action",
-      "version": "1.1.1",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@actions/core": "^1.11.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "buf-action",
-  "version": "1.0.3",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "buf-action",
-      "version": "1.0.3",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@actions/core": "^1.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "buf-action",
-  "version": "1.1.1",
+  "version": "1.1.0",
   "description": "GitHub Action for buf",
   "main": "src/main.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "buf-action",
-  "version": "1.0.3",
+  "version": "1.1.1",
   "description": "GitHub Action for buf",
   "main": "src/main.ts",
   "scripts": {


### PR DESCRIPTION
Below is the draft release notes:

## What's Changed
This release improves support for running the action for GitHub enterprise users. It adds a new parameter `public_github_token` for authentication with the public GitHub. This fixes version resolution and authenticates downloads  for enterprise instances.

* Add post step to run logout by @emcfarlane in https://github.com/bufbuild/buf-action/pull/105
* Fix latest version resolution for GitHub enterprise by @emcfarlane in https://github.com/bufbuild/buf-action/pull/131

**Full Changelog**: https://github.com/bufbuild/buf-action/compare/v1.0.3...v1.1.0