### PR TITLE
Add a `filter` parameter for larger repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Add these parameters under the `with` section of the `uses` step in the workflow
 | `token`                         | API token for [logging into the BSR](https://buf.build/docs/bsr/authentication). | |
 | `domain`                        | Domain for logging into the BSR, enterprise only.| `buf.build` |
 | `input`                         | [Input](https://buf.build/docs/reference/inputs) for the `buf` command. | |
+| `filter`                        | The [`filter`](https://buf.build/docs/reference/inputs/#git) parameter for `breaking_against` | |
 | `paths`                         | Limit to specific files or directories (separated by newlines). | |
 | `exclude_imports`               | Exclude files imported by the target modules. | False |
 | `exclude_paths`                 | Exclude specific files or directories, e.g. "proto/a/a.proto", "proto/a" (separated by newlines). | |

--- a/action.yml
+++ b/action.yml
@@ -67,6 +67,10 @@ inputs:
     description: |-
       Input for the buf command.
     required: false
+  filter:
+    description: |-
+      Value to be passed as the `filter` option. e.g `tree:0`
+    required: false
   paths:
     description: |-
       Limit to specific files or directories (separated by newlines).

--- a/dist/index.js
+++ b/dist/index.js
@@ -47743,6 +47743,7 @@ function getInputs() {
         paths: core.getMultilineInput("paths"),
         exclude_paths: core.getMultilineInput("exclude_paths"),
         exclude_imports: core.getBooleanInput("exclude_imports"),
+        filter: core.getInput("filter"),
         // Inputs specific to buf steps.
         lint: core.getBooleanInput("lint"),
         format: core.getBooleanInput("format"),
@@ -47760,6 +47761,9 @@ function getInputs() {
             if (inputs.input) {
                 inputs.breaking_against += `,subdir=${inputs.input}`;
             }
+            if (inputs.filter) {
+                inputs.breaking_against += `,filter=${inputs.filter}`;
+            }
         }
         inputs.archive_labels.push(lib_github.context.ref);
     }
@@ -47769,6 +47773,9 @@ function getInputs() {
             inputs.breaking_against = `${event.repository.clone_url}#format=git,commit=${event.pull_request.base.sha}`;
             if (inputs.input) {
                 inputs.breaking_against += `,subdir=${inputs.input}`;
+            }
+            if (inputs.filter) {
+                inputs.breaking_against += `,filter=${inputs.filter}`;
             }
         }
         inputs.archive_labels.push(lib_github.context.ref);

--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -31868,6 +31868,7 @@ function getInputs() {
         paths: core.getMultilineInput("paths"),
         exclude_paths: core.getMultilineInput("exclude_paths"),
         exclude_imports: core.getBooleanInput("exclude_imports"),
+        filter: core.getInput("filter"),
         // Inputs specific to buf steps.
         lint: core.getBooleanInput("lint"),
         format: core.getBooleanInput("format"),
@@ -31885,6 +31886,9 @@ function getInputs() {
             if (inputs.input) {
                 inputs.breaking_against += `,subdir=${inputs.input}`;
             }
+            if (inputs.filter) {
+                inputs.breaking_against += `,filter=${inputs.filter}`;
+            }
         }
         inputs.archive_labels.push(github.context.ref);
     }
@@ -31894,6 +31898,9 @@ function getInputs() {
             inputs.breaking_against = `${event.repository.clone_url}#format=git,commit=${event.pull_request.base.sha}`;
             if (inputs.input) {
                 inputs.breaking_against += `,subdir=${inputs.input}`;
+            }
+            if (inputs.filter) {
+                inputs.breaking_against += `,filter=${inputs.filter}`;
             }
         }
         inputs.archive_labels.push(github.context.ref);

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -35,6 +35,7 @@ export interface Inputs {
   paths: string[];
   exclude_paths: string[];
   exclude_imports: boolean;
+  filter: string;
 
   lint: boolean;
   format: boolean;
@@ -62,6 +63,7 @@ export function getInputs(): Inputs {
     paths: core.getMultilineInput("paths"),
     exclude_paths: core.getMultilineInput("exclude_paths"),
     exclude_imports: core.getBooleanInput("exclude_imports"),
+    filter: core.getInput("filter"),
     // Inputs specific to buf steps.
     lint: core.getBooleanInput("lint"),
     format: core.getBooleanInput("format"),
@@ -79,6 +81,9 @@ export function getInputs(): Inputs {
       if (inputs.input) {
         inputs.breaking_against += `,subdir=${inputs.input}`;
       }
+      if (inputs.filter) {
+        inputs.breaking_against += `,filter=${inputs.filter}`;
+      }
     }
     inputs.archive_labels.push(github.context.ref);
   }
@@ -88,6 +93,9 @@ export function getInputs(): Inputs {
       inputs.breaking_against = `${event.repository.clone_url}#format=git,commit=${event.pull_request.base.sha}`;
       if (inputs.input) {
         inputs.breaking_against += `,subdir=${inputs.input}`;
+      }
+      if (inputs.filter) {
+        inputs.breaking_against += `,filter=${inputs.filter}`;
       }
     }
     inputs.archive_labels.push(github.context.ref);


### PR DESCRIPTION
This will generally always be `tree:0` in order to create a treeless clone and sparse checkout of only the input directory.

This improves performance of breaking change checks significantly for larger repositories.

This option was added in [`v1.50.0`](https://github.com/bufbuild/buf/blob/main/CHANGELOG.md#v1500---2025-01-17) which was released only a couple of months ago.

I think it could be nice to automatically add this filter by default or perhaps just to set the default value to `tree:0`?

This would break for anyone using an older version of the CLI.

Not sure of a way that this could be introduced in a backwards compatible manner, maybe we can just run `buf --version` and parse that? Or have `installer.ts` pass through the installed version number?