### PR TITLE
Fix GitHub enterprise without specifying public tokens

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -47857,6 +47857,9 @@ async function installBuf(github, githubToken, inputVersion) {
         }
     }
     if (resolvedVersion === "") {
+        if (!github) {
+            throw new Error(`The version of buf was not provided and the parameter "public_github_token" was not set. Unable to resolve the latest version of buf.`);
+        }
         resolvedVersion = await latestVersion(github);
     }
     if (!semver.satisfies(resolvedVersion, requiredVersion)) {
@@ -48100,10 +48103,13 @@ async function main() {
         if (publicGithubToken == "") {
             // Warn if the public GitHub token is not set. Don't fail as not required.
             core.warning("public_github_token not set, GitHub API requests may be limited");
+            publicGithub = undefined;
         }
-        publicGithub = (0,lib_github.getOctokit)(publicGithubToken, {
-            baseUrl: publicGitHubApiUrl,
-        });
+        else {
+            publicGithub = (0,lib_github.getOctokit)(publicGithubToken, {
+                baseUrl: publicGitHubApiUrl,
+            });
+        }
     }
     const [bufPath, bufVersion] = await installBuf(publicGithub, publicGithubToken, inputs.version);
     core.setOutput(Outputs.BufVersion, bufVersion);

--- a/dist/index.js
+++ b/dist/index.js
@@ -47926,6 +47926,10 @@ async function downloadBuf(version, githubToken) {
     }
     const downloadURL = `https://github.com/bufbuild/buf/releases/download/v${version}/${executable}`;
     const auth = githubToken ? `token ${githubToken}` : undefined;
+    if (!auth) {
+        // Warn if the GitHub token is not set. Don't fail as not required.
+        core.warning("Downloading buf without a GitHub API token, rate limits may apply.");
+    }
     try {
         return await tool_cache.downloadTool(downloadURL, undefined, auth);
     }
@@ -48101,8 +48105,6 @@ async function main() {
         core.info("Running on GitHub Enterprise, using public GitHub API.");
         publicGithubToken = inputs.public_github_token;
         if (publicGithubToken == "") {
-            // Warn if the public GitHub token is not set. Don't fail as not required.
-            core.warning("public_github_token not set, GitHub API requests may be limited");
             publicGithub = undefined;
         }
         else {

--- a/dist/index.js
+++ b/dist/index.js
@@ -47858,7 +47858,7 @@ async function installBuf(github, githubToken, inputVersion) {
     }
     if (resolvedVersion === "") {
         if (!github) {
-            throw new Error(`The version of buf was not provided and the parameter "public_github_token" was not set. Unable to resolve the latest version of buf.`);
+            throw new Error(`Unable to resolve the latest version of buf. Must set the "version" parameter or provide a "public_github_token" to authenticate requests.`);
         }
         resolvedVersion = await latestVersion(github);
     }

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -25,7 +25,7 @@ const requiredVersion = ">=1.35.0";
 // installBuf installs the buf binary and returns the path to the binary. The
 // versionInput should be an explicit version of buf.
 export async function installBuf(
-  github: InstanceType<typeof GitHub>,
+  github: InstanceType<typeof GitHub> | undefined,
   githubToken: string,
   inputVersion: string,
 ): Promise<[string, string]> {
@@ -56,6 +56,11 @@ export async function installBuf(
     }
   }
   if (resolvedVersion === "") {
+    if (!github) {
+      throw new Error(
+        `The version of buf was not provided and the parameter "public_github_token" was not set. Unable to resolve the latest version of buf.`,
+      );
+    }
     resolvedVersion = await latestVersion(github);
   }
   if (!semver.satisfies(resolvedVersion, requiredVersion)) {

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -58,7 +58,7 @@ export async function installBuf(
   if (resolvedVersion === "") {
     if (!github) {
       throw new Error(
-        `The version of buf was not provided and the parameter "public_github_token" was not set. Unable to resolve the latest version of buf.`,
+        `Unable to resolve the latest version of buf. Must set the "version" parameter or provide a "public_github_token" to authenticate requests.`,
       );
     }
     resolvedVersion = await latestVersion(github);

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -156,6 +156,12 @@ async function downloadBuf(
   }
   const downloadURL = `https://github.com/bufbuild/buf/releases/download/v${version}/${executable}`;
   const auth = githubToken ? `token ${githubToken}` : undefined;
+  if (!auth) {
+    // Warn if the GitHub token is not set. Don't fail as not required.
+    core.warning(
+      "Downloading buf without a GitHub API token, rate limits may apply.",
+    );
+  }
   try {
     return await tc.downloadTool(downloadURL, undefined, auth);
   } catch (error) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -47,10 +47,6 @@ async function main() {
     core.info("Running on GitHub Enterprise, using public GitHub API.");
     publicGithubToken = inputs.public_github_token;
     if (publicGithubToken == "") {
-      // Warn if the public GitHub token is not set. Don't fail as not required.
-      core.warning(
-        "public_github_token not set, GitHub API requests may be limited",
-      );
       publicGithub = undefined;
     } else {
       publicGithub = getOctokit(publicGithubToken, {


### PR DESCRIPTION
This fixes enterprise use of the action when not specifying the parameter `public_github_token`. If the version resolution is not required the action does not need to build the GitHub API client. If it is needed an error explaining the issue is now returned.

Closes #143 