### PR TITLE
Prepare for v1.1.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ permissions:
   contents: read
   pull-requests: write
 env:
-  BUF_VERSION: "1.35.0"
+  BUF_VERSION: "1.50.1"
   BUF_MODULE: ${{ vars.BUF_MODULE }}
 jobs:
   build:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ permissions:
   contents: read
   pull-requests: write
 env:
-  BUF_VERSION: "1.50.1"
+  BUF_VERSION: "1.35.0"  # Minimum version we support.
   BUF_MODULE: ${{ vars.BUF_MODULE }}
 jobs:
   build:

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ SHELL := bash
 MAKEFLAGS += --warn-undefined-variables
 MAKEFLAGS += --no-builtin-rules
 MAKEFLAGS += --no-print-directory
-BUF_VERSION ?= 1.35.0
+BUF_VERSION ?= 1.50.1
 
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,6 @@ endif
 	$(SED_I) "s/version: [0-9]+\.[0-9]+\.[0-9]+/version: $(BUF_VERSION)/g" action.yml README.md examples/*.yaml examples/*/*.yaml
 	$(SED_I) "s/buf-action@v[0-9]+(\.[0-9]+)?(\.[0-9]+)?/buf-action@v$(VERSION_SHORT)/g" README.md examples/*.yaml examples/*/*.yaml
 	$(SED_I) "s/\"version\": \"[0-9]+\.[0-9]+\.[0-9]+\"/\"version\": \"$(VERSION)\"/g" package.json
-	$(SED_I) "s/^  BUF_VERSION: \"[0-9]+\.[0-9]+\.[0-9]+\"/  BUF_VERSION: \"$(BUF_VERSION)\"/g" .github/workflows/ci.yaml
 	npm prune
 
 .PHONY: generate

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ inputs:
       Version of the Buf CLI to use.
       Example:
         with:
-          version: 1.35.0
+          version: 1.50.1
     required: false
   token:
     description: |-

--- a/examples/version-input/buf-ci.yaml
+++ b/examples/version-input/buf-ci.yaml
@@ -12,5 +12,5 @@ jobs:
       - uses: bufbuild/buf-action@v1
         with:
           setup_only: true
-          version: 1.35.0
+          version: 1.50.1
       - run: buf version

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "buf-action",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "buf-action",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@actions/core": "^1.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "buf-action",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "GitHub Action for buf",
   "main": "src/main.ts",
   "scripts": {


### PR DESCRIPTION
Release notes:

## What's Changed

* Fix GitHub enterprise use of optional `public_github_token` parameter by @emcfarlane in https://github.com/bufbuild/buf-action/pull/144

**Full Changelog**: https://github.com/bufbuild/buf-action/compare/v1.1.0...v1.1.1