### PR TITLE
Add checksum to verify binary

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,6 +90,17 @@ jobs:
           checksum: fbc18ea896bbea2418b945eda85443a5f144b5ba71193473128a1f417cc5d798
           setup_only: true
       - run: buf --version
+  test-version-checksum-fails:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./
+        continue-on-error: true # setup fails
+        with:
+          version: 1.53.0
+          checksum: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+          setup_only: true
   test-empty-build:
     runs-on: ubuntu-latest
     needs: build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,6 +79,17 @@ jobs:
         with:
           setup_only: true
       - run: buf --version | grep $BUF_VERSION
+  test-version-checksum:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./
+        with:
+          version: 1.53.0
+          checksum: fbc18ea896bbea2418b945eda85443a5f144b5ba71193473128a1f417cc5d798
+          setup_only: true
+      - run: buf --version
   test-empty-build:
     runs-on: ubuntu-latest
     needs: build

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Add these parameters under the `with` section of the `uses` step in the workflow
 | Parameter                       | Description                                        | Default            |
 |:--------------------------------|:---------------------------------------------------|:-------------------|
 | `version`                       | Version of the `buf` CLI to use. | Latest [version][buf-releases] |
+| `checksum`                      | Checksum of the `buf` CLI to verify (sha256). | |
 | `token`                         | API token for [logging into the BSR](https://buf.build/docs/bsr/authentication). | |
 | `domain`                        | Domain for logging into the BSR, enterprise only.| `buf.build` |
 | `input`                         | [Input](https://buf.build/docs/reference/inputs) for the `buf` command. | |

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,10 @@ inputs:
         with:
           version: 1.50.1
     required: false
+  checksum:
+    description:
+      Checksum of the Buf CLI to verify (sha256).
+    required: false
   token:
     description: |-
       API token for logging into the BSR.

--- a/dist/index.js
+++ b/dist/index.js
@@ -47978,17 +47978,13 @@ async function assertChecksum(bufPath, checksum) {
     if (!bufPathOutput) {
         throw new Error(`Unable to find buf binary at ${bufPath}`);
     }
-    await exec.getExecOutput("sha256sum", [bufPathOutput], { silent: true });
+    const sha256sumOutput = await exec.getExecOutput("sha256sum", [bufPathOutput], { silent: true });
     // Checksum is in the format of "checksum filename", so split on space.
-    const checksumParts = checksum.split(" ");
+    const checksumParts = sha256sumOutput.stdout.trim().split(" ");
     if (checksumParts.length !== 2) {
         throw new Error(`Invalid checksum format: ${checksum}. Expected format: "checksum filename"`);
     }
     const checksumValue = checksumParts[0];
-    const checksumFile = checksumParts[1];
-    if (checksumFile !== bufPathOutput) {
-        throw new Error(`Checksum file does not match buf binary: ${checksumFile} != ${bufPathOutput}`);
-    }
     if (checksumValue !== checksum) {
         throw new Error(`Checksum value does not match buf binary, expected ${checksum}, got ${checksumValue}`);
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -47981,7 +47981,8 @@ async function downloadBuf(version, githubToken) {
     }
 }
 // assertChecksum verifies the sha256 checksum of the buf binary.
-async function assertChecksum(bufPath, checksum, algorithm = "sha256") {
+async function assertChecksum(bufPath, checksum) {
+    const shaAlgorithm = "sha256";
     const whichBuf = await exec.getExecOutput("which", [bufPath], {
         ignoreReturnCode: true,
         silent: true,
@@ -47990,7 +47991,7 @@ async function assertChecksum(bufPath, checksum, algorithm = "sha256") {
     if (!bufPathOutput) {
         throw new Error(`Unable to find buf binary at ${bufPath}`);
     }
-    const hash = external_crypto_.createHash(algorithm);
+    const hash = external_crypto_.createHash(shaAlgorithm);
     const pipeline = external_util_.promisify(external_stream_.pipeline);
     await pipeline(external_fs_.createReadStream(bufPathOutput), hash);
     const computedChecksum = hash.digest("hex");

--- a/dist/index.js
+++ b/dist/index.js
@@ -47978,11 +47978,13 @@ async function assertChecksum(bufPath, checksum) {
     if (!bufPathOutput) {
         throw new Error(`Unable to find buf binary at ${bufPath}`);
     }
+    core.info(`Verifying checksum of buf binary at ${bufPathOutput}`);
     const sha256sumOutput = await exec.getExecOutput("sha256sum", [bufPathOutput], { silent: true });
+    core.info(`Checksum output: ${sha256sumOutput.stdout}`);
     // Checksum is in the format of "checksum filename", so split on space.
     const checksumParts = sha256sumOutput.stdout.trim().split(" ");
     if (checksumParts.length !== 2) {
-        throw new Error(`Invalid checksum format: ${checksum}. Expected format: "checksum filename"`);
+        throw new Error(`Invalid checksum format: ${sha256sumOutput.stdout}. Expected format: "checksum filename"`);
     }
     const checksumValue = checksumParts[0];
     if (checksumValue !== checksum) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -47843,6 +47843,10 @@ var tool_cache = __nccwpck_require__(3472);
 var external_crypto_ = __nccwpck_require__(6982);
 // EXTERNAL MODULE: external "fs"
 var external_fs_ = __nccwpck_require__(9896);
+// EXTERNAL MODULE: external "util"
+var external_util_ = __nccwpck_require__(9023);
+// EXTERNAL MODULE: external "stream"
+var external_stream_ = __nccwpck_require__(2203);
 // EXTERNAL MODULE: ./node_modules/semver/index.js
 var semver = __nccwpck_require__(2088);
 ;// CONCATENATED MODULE: ./src/installer.ts
@@ -47859,6 +47863,8 @@ var semver = __nccwpck_require__(2088);
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+
 
 
 
@@ -47984,21 +47990,14 @@ async function assertChecksum(bufPath, checksum, algorithm = "sha256") {
     if (!bufPathOutput) {
         throw new Error(`Unable to find buf binary at ${bufPath}`);
     }
-    const computedChecksum = await computeChecksum(bufPathOutput, algorithm);
+    const hash = external_crypto_.createHash(algorithm);
+    const pipeline = external_util_.promisify(external_stream_.pipeline);
+    await pipeline(external_fs_.createReadStream(bufPathOutput), hash);
+    const computedChecksum = hash.digest("hex");
     if (computedChecksum !== checksum) {
         throw new Error(`Checksum verification failed. Expected: ${checksum}, Computed: ${computedChecksum}`);
     }
     return;
-}
-// computeChecksum hashes the binary, algorithm defaults to sha256.
-async function computeChecksum(filePath, algorithm = "sha256") {
-    return new Promise((resolve, reject) => {
-        const hash = external_crypto_.createHash(algorithm);
-        const stream = external_fs_.createReadStream(filePath);
-        stream.on("error", reject);
-        stream.on("data", (chunk) => hash.update(chunk));
-        stream.on("end", () => resolve(hash.digest("hex")));
-    });
 }
 
 ;// CONCATENATED MODULE: ./src/comment.ts

--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -31857,6 +31857,7 @@ function getInputs() {
     const inputs = {
         version: core.getInput("version"),
         token: core.getInput("token") || getEnv("BUF_TOKEN"),
+        checksum: core.getInput("checksum"),
         domain: core.getInput("domain"),
         setup_only: core.getBooleanInput("setup_only"),
         pr_comment: core.getBooleanInput("pr_comment"),

--- a/examples/version-input/buf-ci.yaml
+++ b/examples/version-input/buf-ci.yaml
@@ -5,7 +5,7 @@ on:
 permissions:
   contents: read
 jobs:
-  buf:      
+  buf:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -23,6 +23,7 @@ import {
 // Inputs are the inputs to the action, matching the inputs in the action.yml.
 export interface Inputs {
   version: string;
+  checksum: string;
   token: string;
   domain: string;
   setup_only: boolean;
@@ -51,6 +52,7 @@ export function getInputs(): Inputs {
   const inputs: Inputs = {
     version: core.getInput("version"),
     token: core.getInput("token") || getEnv("BUF_TOKEN"),
+    checksum: core.getInput("checksum"),
     domain: core.getInput("domain"),
     setup_only: core.getBooleanInput("setup_only"),
     pr_comment: core.getBooleanInput("pr_comment"),

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -184,21 +184,19 @@ export async function assertChecksum(
   if (!bufPathOutput) {
     throw new Error(`Unable to find buf binary at ${bufPath}`);
   }
-  await exec.getExecOutput("sha256sum", [bufPathOutput], { silent: true });
+  const sha256sumOutput = await exec.getExecOutput(
+    "sha256sum",
+    [bufPathOutput],
+    { silent: true },
+  );
   // Checksum is in the format of "checksum filename", so split on space.
-  const checksumParts = checksum.split(" ");
+  const checksumParts = sha256sumOutput.stdout.trim().split(" ");
   if (checksumParts.length !== 2) {
     throw new Error(
       `Invalid checksum format: ${checksum}. Expected format: "checksum filename"`,
     );
   }
   const checksumValue = checksumParts[0];
-  const checksumFile = checksumParts[1];
-  if (checksumFile !== bufPathOutput) {
-    throw new Error(
-      `Checksum file does not match buf binary: ${checksumFile} != ${bufPathOutput}`,
-    );
-  }
   if (checksumValue !== checksum) {
     throw new Error(
       `Checksum value does not match buf binary, expected ${checksum}, got ${checksumValue}`,

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -179,8 +179,8 @@ async function downloadBuf(
 export async function assertChecksum(
   bufPath: string,
   checksum: string,
-  algorithm: string = "sha256",
 ): Promise<void> {
+  const shaAlgorithm = "sha256";
   const whichBuf = await exec.getExecOutput("which", [bufPath], {
     ignoreReturnCode: true,
     silent: true,
@@ -189,7 +189,7 @@ export async function assertChecksum(
   if (!bufPathOutput) {
     throw new Error(`Unable to find buf binary at ${bufPath}`);
   }
-  const hash = crypto.createHash(algorithm);
+  const hash = crypto.createHash(shaAlgorithm);
   const pipeline = util.promisify(stream.pipeline);
   await pipeline(fs.createReadStream(bufPathOutput), hash);
   const computedChecksum = hash.digest("hex");

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -184,16 +184,18 @@ export async function assertChecksum(
   if (!bufPathOutput) {
     throw new Error(`Unable to find buf binary at ${bufPath}`);
   }
+  core.info(`Verifying checksum of buf binary at ${bufPathOutput}`);
   const sha256sumOutput = await exec.getExecOutput(
     "sha256sum",
     [bufPathOutput],
     { silent: true },
   );
+  core.info(`Checksum output: ${sha256sumOutput.stdout}`);
   // Checksum is in the format of "checksum filename", so split on space.
   const checksumParts = sha256sumOutput.stdout.trim().split(" ");
   if (checksumParts.length !== 2) {
     throw new Error(
-      `Invalid checksum format: ${checksum}. Expected format: "checksum filename"`,
+      `Invalid checksum format: ${sha256sumOutput.stdout}. Expected format: "checksum filename"`,
     );
   }
   const checksumValue = checksumParts[0];

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,7 +27,7 @@ import * as parseDiff from "parse-diff";
 
 import { getInputs, Inputs, getEnv } from "./inputs";
 import { Outputs } from "./outputs";
-import { installBuf } from "./installer";
+import { installBuf, assertChecksum } from "./installer";
 import { findCommentOnPR, commentOnPR } from "./comment";
 import { parseModuleNames, ModuleName } from "./config";
 
@@ -59,6 +59,11 @@ async function main() {
     publicGithubToken,
     inputs.version,
   );
+  if (inputs.checksum) {
+    core.info(`Verifying checksum ${inputs.checksum}`);
+    await assertChecksum(bufPath, inputs.checksum);
+    core.info("Checksum verification passed");
+  }
   core.setOutput(Outputs.BufVersion, bufVersion);
   core.setOutput(Outputs.BufPath, bufPath);
   core.saveState(Outputs.BufPath, bufPath);


### PR DESCRIPTION
This PR adds a new parameter `checksum` to the GitHub action input to validate the sha256 hash of the installed buf binary.

Closes #168 