### PR TITLE
Fix windows install chmod

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -47939,7 +47939,7 @@ async function installBuf(github, githubToken, inputVersion) {
     if (!cachePath) {
         core.info(`Downloading buf (${resolvedVersion})`);
         const downloadPath = await downloadBuf(resolvedVersion, githubToken);
-        //await exec.exec("chmod", ["+x", downloadPath]);
+        await external_fs_.promises.chmod(downloadPath, 0o755);
         cachePath = await tool_cache.cacheFile(downloadPath, binName, bufName, resolvedVersion);
     }
     core.addPath(cachePath);

--- a/dist/index.js
+++ b/dist/index.js
@@ -47939,7 +47939,7 @@ async function installBuf(github, githubToken, inputVersion) {
     if (!cachePath) {
         core.info(`Downloading buf (${resolvedVersion})`);
         const downloadPath = await downloadBuf(resolvedVersion, githubToken);
-        await exec.exec("chmod", ["+x", downloadPath]);
+        //await exec.exec("chmod", ["+x", downloadPath]);
         cachePath = await tool_cache.cacheFile(downloadPath, binName, bufName, resolvedVersion);
     }
     core.addPath(cachePath);

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -75,7 +75,7 @@ export async function installBuf(
   if (!cachePath) {
     core.info(`Downloading buf (${resolvedVersion})`);
     const downloadPath = await downloadBuf(resolvedVersion, githubToken);
-    //await exec.exec("chmod", ["+x", downloadPath]);
+    await fs.promises.chmod(downloadPath, 0o755);
     cachePath = await tc.cacheFile(
       downloadPath,
       binName,

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -75,7 +75,7 @@ export async function installBuf(
   if (!cachePath) {
     core.info(`Downloading buf (${resolvedVersion})`);
     const downloadPath = await downloadBuf(resolvedVersion, githubToken);
-    await exec.exec("chmod", ["+x", downloadPath]);
+    //await exec.exec("chmod", ["+x", downloadPath]);
     cachePath = await tc.cacheFile(
       downloadPath,
       binName,


### PR DESCRIPTION
This fixes windows install compatibility by changing `exec` to use `fs.promise` on setting file permissions.