### PR TITLE
Add breaking against registry parameter

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -349,6 +349,8 @@ jobs:
           printf "syntax = \"proto3\";\npackage foo.v1;\nmessage Bar {}\n" > proto/foo/v1/bar.proto
       - uses: ./
         with:
+          token: ${{ secrets.BUF_TOKEN }}
+          version: v1.51.0 # Version that supports --against-registry.
           input: .
           lint: false
           format: false

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -167,21 +167,6 @@ jobs:
           push: false
           archive: false
           pr_comment: false
-  test-breaking-against-registry:
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./
-        with:
-          input: buf.build/bufbuild/registry:main
-          lint: false
-          format: false
-          breaking: true
-          breaking_against_registry: true
-          push: false
-          archive: false
-          pr_comment: false
   test-comment:
     runs-on: ubuntu-latest
     # Only run on pull requests from the same repository, comments from forks are not tested. Dependabot is skipped.
@@ -350,13 +335,33 @@ jobs:
           push: true
           archive: false
           pr_comment: false
-  test-archive:
-    if: github.event_name == 'push' && github.ref_name != github.event.repository.default_branch
+  test-breaking-against-registry:
     runs-on: ubuntu-latest
     needs:
       - test-push
       - test-push-token-only
       - test-push-unnamed
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          mkdir -p proto/foo/v1
+          printf "version: v2\nmodules:\n  - path: proto\n    name: ${BUF_MODULE}\n" > buf.yaml
+          printf "syntax = \"proto3\";\npackage foo.v1;\nmessage Bar {}\n" > proto/foo/v1/bar.proto
+      - uses: ./
+        with:
+          input: .
+          lint: false
+          format: false
+          breaking: true
+          breaking_against_registry: true
+          push: false
+          archive: false
+          pr_comment: false
+  test-archive:
+    if: github.event_name == 'push' && github.ref_name != github.event.repository.default_branch
+    runs-on: ubuntu-latest
+    needs:
+      - test-breaking-against-registry
     steps:
       - uses: actions/checkout@v4
       - run: |
@@ -376,9 +381,7 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     needs:
-      - test-push
-      - test-push-token-only
-      - test-push-unnamed
+      - test-breaking-against-registry
     steps:
       - uses: actions/checkout@v4
       - run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -350,7 +350,7 @@ jobs:
       - uses: ./
         with:
           token: ${{ secrets.BUF_TOKEN }}
-          version: v1.51.0 # Version that supports --against-registry.
+          version: 1.51.0 # Version that supports --against-registry.
           input: .
           lint: false
           format: false

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -167,6 +167,21 @@ jobs:
           push: false
           archive: false
           pr_comment: false
+  test-breaking-against-registry:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./
+        with:
+          input: buf.build/bufbuild/registry:main
+          lint: false
+          format: false
+          breaking: true
+          breaking_against_registry: true
+          push: false
+          archive: false
+          pr_comment: false
   test-comment:
     runs-on: ubuntu-latest
     # Only run on pull requests from the same repository, comments from forks are not tested. Dependabot is skipped.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Add these parameters under the `with` section of the `uses` step in the workflow
 | `lint`                          | Whether to run the linting step. | Runs on pushes to Git PR |
 | `breaking`                      | Whether to run the breaking change detection step. | Runs on pushes to Git PR |
 | `breaking_against`              | [Input](https://buf.build/docs/reference/inputs) to compare against. | Base of the PR or the commit before the event |
+| `breaking_against_registry`     | Whether to use the Buf Schema Registry for breaking change detection. If true, the `breaking_against` parameter is ignored. | False |
 | `push`                          | Whether to run the push step. | Runs on Git pushes (non forks) |
 | `push_disable_create`           | Disables repository creation if it does not exist. | False |
 | `archive`                       | Whether to run the archive step. | Runs on Git deletes (non forks) |

--- a/action.yml
+++ b/action.yml
@@ -120,6 +120,13 @@ inputs:
       Input to compare against for breaking change detection.
       Defaults to the base branch of the pull request or the commit before the push.
     required: false
+  breaking_against_registry:
+    description: |-
+      Whether to use the Buf Schema Registry for breaking change detection.
+      If true, the `breaking_against` input is ignored.
+      Defaults to false.
+    required: false
+    default: "false"
 
   push:
     description: |-

--- a/action.yml
+++ b/action.yml
@@ -123,7 +123,7 @@ inputs:
   breaking_against_registry:
     description: |-
       Whether to use the Buf Schema Registry for breaking change detection.
-      If true, the `breaking_against` input is ignored.
+      If true, the `breaking_against` parameter is ignored.
       Defaults to false.
     required: false
     default: "false"

--- a/dist/index.js
+++ b/dist/index.js
@@ -47805,6 +47805,7 @@ function getInputs() {
         format: core.getBooleanInput("format"),
         breaking: core.getBooleanInput("breaking"),
         breaking_against: core.getInput("breaking_against"),
+        breaking_against_registry: core.getBooleanInput("breaking_against_registry"),
         push: core.getBooleanInput("push"),
         push_disable_create: core.getBooleanInput("push_disable_create"),
         archive: core.getBooleanInput("archive"),
@@ -47812,7 +47813,7 @@ function getInputs() {
     };
     if (lib_github.context.eventName === "push") {
         const event = lib_github.context.payload;
-        if (inputs.breaking_against === "") {
+        if (inputs.breaking_against === "" && !inputs.breaking_against_registry) {
             inputs.breaking_against = `${event.repository.clone_url}#format=git,commit=${event.before}`;
             if (inputs.input) {
                 inputs.breaking_against += `,subdir=${inputs.input}`;
@@ -47822,7 +47823,7 @@ function getInputs() {
     }
     if (lib_github.context.eventName === "pull_request") {
         const event = lib_github.context.payload;
-        if (inputs.breaking_against === "") {
+        if (inputs.breaking_against === "" && !inputs.breaking_against_registry) {
             inputs.breaking_against = `${event.repository.clone_url}#format=git,commit=${event.pull_request.base.sha}`;
             if (inputs.input) {
                 inputs.breaking_against += `,subdir=${inputs.input}`;
@@ -48391,13 +48392,13 @@ async function breaking(bufPath, inputs) {
         core.debug("Skipping breaking");
         return skip();
     }
-    const args = [
-        "breaking",
-        "--error-format",
-        "github-actions",
-        "--against",
-        inputs.breaking_against,
-    ];
+    const args = ["breaking", "--error-format", "github-actions"];
+    if (inputs.breaking_against_registry) {
+        args.push("--against-registry");
+    }
+    else {
+        args.push("--against", inputs.breaking_against);
+    }
     if (inputs.input) {
         args.push(inputs.input);
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -47904,8 +47904,8 @@ var semver = __nccwpck_require__(2088);
 
 // requiredVersion is the minimum version of buf required.
 const requiredVersion = ">=1.35.0";
-// requiredVersionForBreaking is the minimum version of buf required for breaking
-// against registry checks.
+// requiredVersionForBreakingAgainstRegistry is the minimum version of buf
+// required for breaking against registry checks.
 const requiredVersionForBreakingAgainstRegistry = ">=1.51.0";
 // installBuf installs the buf binary and returns the path to the binary. The
 // versionInput should be an explicit version of buf.

--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -31875,6 +31875,7 @@ function getInputs() {
         format: core.getBooleanInput("format"),
         breaking: core.getBooleanInput("breaking"),
         breaking_against: core.getInput("breaking_against"),
+        breaking_against_registry: core.getBooleanInput("breaking_against_registry"),
         push: core.getBooleanInput("push"),
         push_disable_create: core.getBooleanInput("push_disable_create"),
         archive: core.getBooleanInput("archive"),
@@ -31882,7 +31883,7 @@ function getInputs() {
     };
     if (github.context.eventName === "push") {
         const event = github.context.payload;
-        if (inputs.breaking_against === "") {
+        if (inputs.breaking_against === "" && !inputs.breaking_against_registry) {
             inputs.breaking_against = `${event.repository.clone_url}#format=git,commit=${event.before}`;
             if (inputs.input) {
                 inputs.breaking_against += `,subdir=${inputs.input}`;
@@ -31892,7 +31893,7 @@ function getInputs() {
     }
     if (github.context.eventName === "pull_request") {
         const event = github.context.payload;
-        if (inputs.breaking_against === "") {
+        if (inputs.breaking_against === "" && !inputs.breaking_against_registry) {
             inputs.breaking_against = `${event.repository.clone_url}#format=git,commit=${event.pull_request.base.sha}`;
             if (inputs.input) {
                 inputs.breaking_against += `,subdir=${inputs.input}`;

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -41,6 +41,7 @@ export interface Inputs {
   format: boolean;
   breaking: boolean;
   breaking_against: string;
+  breaking_against_registry: boolean;
   push: boolean;
   push_disable_create: boolean;
   archive: boolean;
@@ -69,6 +70,9 @@ export function getInputs(): Inputs {
     format: core.getBooleanInput("format"),
     breaking: core.getBooleanInput("breaking"),
     breaking_against: core.getInput("breaking_against"),
+    breaking_against_registry: core.getBooleanInput(
+      "breaking_against_registry",
+    ),
     push: core.getBooleanInput("push"),
     push_disable_create: core.getBooleanInput("push_disable_create"),
     archive: core.getBooleanInput("archive"),
@@ -76,7 +80,7 @@ export function getInputs(): Inputs {
   };
   if (github.context.eventName === "push") {
     const event = github.context.payload as PushEvent;
-    if (inputs.breaking_against === "") {
+    if (inputs.breaking_against === "" && !inputs.breaking_against_registry) {
       inputs.breaking_against = `${event.repository.clone_url}#format=git,commit=${event.before}`;
       if (inputs.input) {
         inputs.breaking_against += `,subdir=${inputs.input}`;
@@ -86,7 +90,7 @@ export function getInputs(): Inputs {
   }
   if (github.context.eventName === "pull_request") {
     const event = github.context.payload as PullRequestEvent;
-    if (inputs.breaking_against === "") {
+    if (inputs.breaking_against === "" && !inputs.breaking_against_registry) {
       inputs.breaking_against = `${event.repository.clone_url}#format=git,commit=${event.pull_request.base.sha}`;
       if (inputs.input) {
         inputs.breaking_against += `,subdir=${inputs.input}`;

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -27,8 +27,8 @@ import { getEnv, Inputs } from "./inputs";
 // requiredVersion is the minimum version of buf required.
 const requiredVersion = ">=1.35.0";
 
-// requiredVersionForBreaking is the minimum version of buf required for breaking
-// against registry checks.
+// requiredVersionForBreakingAgainstRegistry is the minimum version of buf
+// required for breaking against registry checks.
 const requiredVersionForBreakingAgainstRegistry = ">=1.51.0";
 
 // installBuf installs the buf binary and returns the path to the binary. The

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,7 +27,7 @@ import * as parseDiff from "parse-diff";
 
 import { getInputs, Inputs, getEnv } from "./inputs";
 import { Outputs } from "./outputs";
-import { installBuf, assertChecksum } from "./installer";
+import { installBuf, assertBufForInputs } from "./installer";
 import { findCommentOnPR, commentOnPR } from "./comment";
 import { parseModuleNames, ModuleName } from "./config";
 
@@ -59,11 +59,7 @@ async function main() {
     publicGithubToken,
     inputs.version,
   );
-  if (inputs.checksum) {
-    core.info(`Verifying checksum ${inputs.checksum}`);
-    await assertChecksum(bufPath, inputs.checksum);
-    core.info("Checksum verification passed");
-  }
+  await assertBufForInputs(bufPath, bufVersion, inputs);
   core.setOutput(Outputs.BufVersion, bufVersion);
   core.setOutput(Outputs.BufPath, bufPath);
   core.saveState(Outputs.BufPath, bufPath);

--- a/src/main.ts
+++ b/src/main.ts
@@ -300,13 +300,12 @@ async function breaking(bufPath: string, inputs: Inputs): Promise<Result> {
     core.debug("Skipping breaking");
     return skip();
   }
-  const args = [
-    "breaking",
-    "--error-format",
-    "github-actions",
-    "--against",
-    inputs.breaking_against,
-  ];
+  const args = ["breaking", "--error-format", "github-actions"];
+  if (inputs.breaking_against_registry) {
+    args.push("--against-registry");
+  } else {
+    args.push("--against", inputs.breaking_against);
+  }
   if (inputs.input) {
     args.push(inputs.input);
   }


### PR DESCRIPTION
This PR adds a new parameter `breaking_against_registry` which enables setting the new buf flag [--breaking-against-registry](https://buf.build/docs/reference/cli/buf/breaking/#against-registry). If the flag  is set, the version of buf is required to be `>=1.51.0` to when the feature was introduced. This avoids requiring the min version changed.