### PR TITLE
Fix push and archive status message on non-passed results

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -48266,11 +48266,15 @@ function createSummary(inputs, steps, moduleNames) {
     ];
     // If push or archive is enabled add a link to the registry.
     let output = core.summary.addTable(table);
-    if (inputs.push && moduleNames.length > 0) {
+    if (inputs.push &&
+        moduleNames.length > 0 &&
+        steps.push?.status == Status.Passed) {
         const modules = moduleNames.map((moduleName) => `<a href="https://${moduleName.name}">${moduleName.name}</a>`);
         output = output.addRaw(`Pushed to ${modules.join(", ")}.`, true);
     }
-    if (inputs.archive && moduleNames.length > 0) {
+    if (inputs.archive &&
+        moduleNames.length > 0 &&
+        steps.archive?.status == Status.Passed) {
         const modules = moduleNames.map((moduleName) => `<a href="https://${moduleName.name}">${moduleName.name}</a>`);
         output = output.addRaw(`Archived labels ${inputs.archive_labels.join(", ")} to ${modules.join(", ")}.`, true);
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -154,14 +154,22 @@ function createSummary(
   ];
   // If push or archive is enabled add a link to the registry.
   let output = core.summary.addTable(table);
-  if (inputs.push && moduleNames.length > 0) {
+  if (
+    inputs.push &&
+    moduleNames.length > 0 &&
+    steps.push?.status == Status.Passed
+  ) {
     const modules = moduleNames.map(
       (moduleName) =>
         `<a href="https://${moduleName.name}">${moduleName.name}</a>`,
     );
     output = output.addRaw(`Pushed to ${modules.join(", ")}.`, true);
   }
-  if (inputs.archive && moduleNames.length > 0) {
+  if (
+    inputs.archive &&
+    moduleNames.length > 0 &&
+    steps.archive?.status == Status.Passed
+  ) {
     const modules = moduleNames.map(
       (moduleName) =>
         `<a href="https://${moduleName.name}">${moduleName.name}</a>`,


### PR DESCRIPTION
This PR limits the message of push and archive steps to only the passing state. These messages are only set on a pull request so are not normally visible.