### PR TITLE
Prepare for v1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "buf-action",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "buf-action",
-      "version": "1.1.4",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@actions/core": "^1.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "buf-action",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "description": "GitHub Action for buf",
   "main": "src/main.ts",
   "scripts": {


### PR DESCRIPTION
Below are the draft release notes:

## What's Changed
* Add `breaking_against_registry` parameter to allow breaking to run against the BSR by @emcfarlane in https://github.com/bufbuild/buf-action/pull/190
* Fix push and archive status message on non-passed results by @emcfarlane in https://github.com/bufbuild/buf-action/pull/191


**Full Changelog**: https://github.com/bufbuild/buf-action/compare/v1.1.4...v1.2.0