### PR TITLE
Add push_create_visibility parameter

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -263,6 +263,7 @@ jobs:
           format: false
           breaking: false
           push: true
+          push_create_visibility: private # Push to the public registry.
           archive: false
           pr_comment: false
   test-push-token-only:

--- a/action.yml
+++ b/action.yml
@@ -133,6 +133,12 @@ inputs:
       Whether to run the push step. Runs by default on pushes, for non forked repositories.
     required: false
     default: ${{ github.event_name == 'push' }}
+  push_create_visibility:
+    description: |-
+      Repository's visibility setting if created.
+      Must be either "public" or "private". Defaults to "private".
+    required: false
+    default: "private"
   push_disable_create:
     description: |-
       Disables repository creation if it does not exist. Defaults to false.

--- a/action.yml
+++ b/action.yml
@@ -136,9 +136,8 @@ inputs:
   push_create_visibility:
     description: |-
       Repository's visibility setting if created.
-      Must be either "public" or "private". Defaults to "private".
+      Must be either "public" or "private". Defaults to private.
     required: false
-    default: "private"
   push_disable_create:
     description: |-
       Disables repository creation if it does not exist. Defaults to false.

--- a/dist/index.js
+++ b/dist/index.js
@@ -47943,7 +47943,7 @@ function getInputs() {
         breaking_against: core.getInput("breaking_against"),
         breaking_against_registry: core.getBooleanInput("breaking_against_registry"),
         push: core.getBooleanInput("push"),
-        push_create_visibility: core.getInput("push_create_visibiltiy"),
+        push_create_visibility: core.getInput("push_create_visibility"),
         push_disable_create: core.getBooleanInput("push_disable_create"),
         archive: core.getBooleanInput("archive"),
         archive_labels: [],

--- a/dist/index.js
+++ b/dist/index.js
@@ -47943,6 +47943,7 @@ function getInputs() {
         breaking_against: core.getInput("breaking_against"),
         breaking_against_registry: core.getBooleanInput("breaking_against_registry"),
         push: core.getBooleanInput("push"),
+        push_create_visibility: core.getInput("push_create_visibility"),
         push_disable_create: core.getBooleanInput("push_disable_create"),
         archive: core.getBooleanInput("archive"),
         archive_labels: [],
@@ -48591,6 +48592,9 @@ async function push(bufPath, inputs, moduleNames) {
     ];
     if (!inputs.push_disable_create) {
         args.push("--create");
+        if (inputs.push_create_visibility) {
+            args.push("--create-visibility", inputs.push_create_visibility);
+        }
     }
     if (inputs.input) {
         args.push(inputs.input);

--- a/dist/index.js
+++ b/dist/index.js
@@ -47943,7 +47943,7 @@ function getInputs() {
         breaking_against: core.getInput("breaking_against"),
         breaking_against_registry: core.getBooleanInput("breaking_against_registry"),
         push: core.getBooleanInput("push"),
-        push_create_visibility: core.getInput("push_create_visibility"),
+        push_create_visibility: core.getInput("push_create_visibiltiy"),
         push_disable_create: core.getBooleanInput("push_disable_create"),
         archive: core.getBooleanInput("archive"),
         archive_labels: [],

--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -31877,7 +31877,7 @@ function getInputs() {
         breaking_against: core.getInput("breaking_against"),
         breaking_against_registry: core.getBooleanInput("breaking_against_registry"),
         push: core.getBooleanInput("push"),
-        push_create_visibility: core.getInput("push_create_visibiltiy"),
+        push_create_visibility: core.getInput("push_create_visibility"),
         push_disable_create: core.getBooleanInput("push_disable_create"),
         archive: core.getBooleanInput("archive"),
         archive_labels: [],

--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -31877,6 +31877,7 @@ function getInputs() {
         breaking_against: core.getInput("breaking_against"),
         breaking_against_registry: core.getBooleanInput("breaking_against_registry"),
         push: core.getBooleanInput("push"),
+        push_create_visibility: core.getInput("push_create_visibility"),
         push_disable_create: core.getBooleanInput("push_disable_create"),
         archive: core.getBooleanInput("archive"),
         archive_labels: [],

--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -31877,7 +31877,7 @@ function getInputs() {
         breaking_against: core.getInput("breaking_against"),
         breaking_against_registry: core.getBooleanInput("breaking_against_registry"),
         push: core.getBooleanInput("push"),
-        push_create_visibility: core.getInput("push_create_visibility"),
+        push_create_visibility: core.getInput("push_create_visibiltiy"),
         push_disable_create: core.getBooleanInput("push_disable_create"),
         archive: core.getBooleanInput("archive"),
         archive_labels: [],

--- a/examples/push-create-public/buf-ci.yaml
+++ b/examples/push-create-public/buf-ci.yaml
@@ -1,0 +1,19 @@
+# This workflow shows pushing new modules with public visibility.
+name: Buf CI
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+  delete:
+permissions:
+  contents: read
+jobs:
+  buf:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: bufbuild/buf-action@v1
+        with:
+          token: ${{ secrets.BUF_TOKEN }}
+          # The `push_create_visibility` option is used to set the visibility of the new module.
+          push_create_visibility: public

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -75,7 +75,7 @@ export function getInputs(): Inputs {
       "breaking_against_registry",
     ),
     push: core.getBooleanInput("push"),
-    push_create_visibility: core.getInput("push_create_visibility"),
+    push_create_visibility: core.getInput("push_create_visibiltiy"),
     push_disable_create: core.getBooleanInput("push_disable_create"),
     archive: core.getBooleanInput("archive"),
     archive_labels: [],

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -75,7 +75,7 @@ export function getInputs(): Inputs {
       "breaking_against_registry",
     ),
     push: core.getBooleanInput("push"),
-    push_create_visibility: core.getInput("push_create_visibiltiy"),
+    push_create_visibility: core.getInput("push_create_visibility"),
     push_disable_create: core.getBooleanInput("push_disable_create"),
     archive: core.getBooleanInput("archive"),
     archive_labels: [],

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -43,6 +43,7 @@ export interface Inputs {
   breaking_against: string;
   breaking_against_registry: boolean;
   push: boolean;
+  push_create_visibility: string;
   push_disable_create: boolean;
   archive: boolean;
   archive_labels: string[];
@@ -74,6 +75,7 @@ export function getInputs(): Inputs {
       "breaking_against_registry",
     ),
     push: core.getBooleanInput("push"),
+    push_create_visibility: core.getInput("push_create_visibility"),
     push_disable_create: core.getBooleanInput("push_disable_create"),
     archive: core.getBooleanInput("archive"),
     archive_labels: [],

--- a/src/main.ts
+++ b/src/main.ts
@@ -354,6 +354,9 @@ async function push(
   ];
   if (!inputs.push_disable_create) {
     args.push("--create");
+    if (inputs.push_create_visibility) {
+      args.push("--create-visibility", inputs.push_create_visibility);
+    }
   }
   if (inputs.input) {
     args.push(inputs.input);


### PR DESCRIPTION
This adds the parameter `push_create_visibility` to allow setting the visibility to public on creation of new modules with buf push. 

Fixes https://github.com/bufbuild/buf-action/issues/150