### PR TITLE
Update GHA examples

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ jobs:
   buf:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: bufbuild/buf-action@v1
         with:
           token: ${{ secrets.BUF_TOKEN }}

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ inputs:
       Version of the Buf CLI to use.
       Example:
         with:
-          version: 1.50.1
+          version: 1.72.0
     required: false
   checksum:
     description:

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,16 +6,21 @@ This directory contains examples of how to use the `buf` GitHub Action.
 
 - [buf-ci.yaml](./buf-ci.yaml): Recommended configuration for using `buf` in a CI environment.
 
+- [enterprise/buf-ci.yaml](./enterprise/buf-ci.yaml): Default configuration for GitHub Enterprise Server.
+
 - [only-checks/buf-ci.yaml](./only-checks/buf-ci.yaml): How to use `buf` to only run checks on pull requests.
 - [only-setup/buf-ci.yaml](./only-setup/buf-ci.yaml): How to use `buf` to only install `buf`.
 - [only-setup-defaults/buf-ci.yaml](./only-setup-defaults/buf-ci.yaml): Showcases the default steps of the `buf` action.
 - [only-sync/buf-ci.yaml](./only-sync/buf-ci.yaml): How to use `buf` to only sync the repository labels.
 
+- [push-create-public/buf-ci.yaml](./push-create-public/buf-ci.yaml): Creates new modules with public visibility.
 - [push-on-changes/buf-ci.yaml](./push-on-changes/buf-ci.yaml): Pushes changes only on detecting protobuf file changes.
 
+- [disable-skip/buf-ci.yaml](./disable-skip/buf-ci.yaml): How to disable the `buf skip` labels entirely.
 - [skip-on-commits/buf-ci.yaml](./skip-on-commits/buf-ci.yaml): How to use commit messages to skip `buf` checks on push.
 - [skip-on-labels/buf-ci.yaml](./skip-on-labels/buf-ci.yaml): How to use custom labels to skip `buf` checks on pull requests.
 
+- [check-before-push/buf-ci.yaml](./check-before-push/buf-ci.yaml): Run checks against the `main` branch before pushing on a Git branch.
 - [validate-push/buf-ci.yaml](./validate-push/buf-ci.yaml): Validate checks before pushing to the repository.
 
 - [version-env/buf-ci.yaml](./version-env/buf-ci.yaml): Resolve the `buf` version from an environment variable (`BUF_VERSION`).

--- a/examples/buf-ci.yaml
+++ b/examples/buf-ci.yaml
@@ -12,7 +12,7 @@ jobs:
   buf:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: bufbuild/buf-action@v1
         with:
           token: ${{ secrets.BUF_TOKEN }}

--- a/examples/check-before-push/buf-ci.yaml
+++ b/examples/check-before-push/buf-ci.yaml
@@ -6,10 +6,10 @@ on:
 permissions:
   contents: read
 jobs:
-  buf:      
+  buf:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: bufbuild/buf-action@v1
         with:
           token: ${{ secrets.BUF_TOKEN }}

--- a/examples/disable-skip/buf-ci.yaml
+++ b/examples/disable-skip/buf-ci.yaml
@@ -10,11 +10,12 @@ on:
   delete:
 permissions:
   contents: read
+  pull-requests: write
 jobs:
   buf:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: bufbuild/buf-action@v1
         with:
           token: ${{ secrets.BUF_TOKEN }}

--- a/examples/enterprise/buf-ci.yaml
+++ b/examples/enterprise/buf-ci.yaml
@@ -12,7 +12,7 @@ jobs:
   buf:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: bufbuild/buf-action@v1
         with:
           token: ${{ secrets.BUF_TOKEN }}

--- a/examples/only-checks/buf-ci.yaml
+++ b/examples/only-checks/buf-ci.yaml
@@ -7,8 +7,8 @@ permissions:
   contents: read
   pull-requests: write
 jobs:
-  buf:      
+  buf:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: bufbuild/buf-action@v1

--- a/examples/only-setup-defaults/buf-ci.yaml
+++ b/examples/only-setup-defaults/buf-ci.yaml
@@ -13,7 +13,7 @@ jobs:
   buf:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: bufbuild/buf-action@v1
         with:
           setup_only: true
@@ -21,15 +21,18 @@ jobs:
           BUF_TOKEN: ${{ secrets.BUF_TOKEN }}
         run: echo ${BUF_TOKEN} | buf registry login buf.build --token-stdin
       - run: buf build --error-format=github-actions
-      - if: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'buf skip lint') }}
+      - if: ${{ github.event_name == 'pull_request' }}
         run: buf lint --error-format github-actions
-      - if: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'buf skip format') }}
+      - if: ${{ github.event_name == 'pull_request' }}
         run: buf format --diff --error-format github-actions --exit-code
       - if: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'buf skip breaking') }}
         run: |
           buf breaking --error-format github-actions --against \
-            ${{ github.event.repository.clone_url }}#format=git,tag=${{ github.event.pull_request.base.sha || github.event.before }}
+            ${{ github.event.repository.clone_url }}#format=git,ref=${{ github.event.pull_request.base.sha || github.event.before }}
       - if: ${{ github.event_name == 'push' }}
         run: buf push --error-format github-actions --create --git-metadata
+      # The action resolves the module names from buf.yaml and archives the
+      # deleted ref as a label on each one. Replace buf.build/acme/weather with
+      # the modules in this repository.
       - if: ${{ github.event_name == 'delete' }}
-        run: buf beta registry archive --label ${{ github.ref_name }}
+        run: buf registry module label archive buf.build/acme/weather:${{ github.event.ref }}

--- a/examples/only-setup/buf-ci.yaml
+++ b/examples/only-setup/buf-ci.yaml
@@ -6,10 +6,10 @@ on:
 permissions:
   contents: read
 jobs:
-  buf:      
+  buf:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: bufbuild/buf-action@v1
         with:
           # Add the parameter token as a secret in your repository settings

--- a/examples/only-sync/buf-ci.yaml
+++ b/examples/only-sync/buf-ci.yaml
@@ -6,10 +6,10 @@ on:
 permissions:
   contents: read
 jobs:
-  buf:      
+  buf:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: bufbuild/buf-action@v1
         with:
           token: ${{ secrets.BUF_TOKEN }}

--- a/examples/push-create-public/buf-ci.yaml
+++ b/examples/push-create-public/buf-ci.yaml
@@ -7,11 +7,12 @@ on:
   delete:
 permissions:
   contents: read
+  pull-requests: write
 jobs:
   buf:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: bufbuild/buf-action@v1
         with:
           token: ${{ secrets.BUF_TOKEN }}

--- a/examples/push-on-changes/buf-ci.yaml
+++ b/examples/push-on-changes/buf-ci.yaml
@@ -1,4 +1,4 @@
-# This workflow shows syncing changes only when the buf.yaml, README.md, LICENSE 
+# This workflow shows syncing changes only when the buf.yaml, README.md, LICENSE
 # or .proto files are modified.
 # Caution: Restricting push can cause unintended behavior. Review the paths carefully.
 name: Buf CI
@@ -18,7 +18,7 @@ jobs:
   buf:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: bufbuild/buf-action@v1
         with:
           token: ${{ secrets.BUF_TOKEN }}

--- a/examples/skip-on-commits/buf-ci.yaml
+++ b/examples/skip-on-commits/buf-ci.yaml
@@ -6,10 +6,10 @@ on:
 permissions:
   contents: read
 jobs:
-  buf:      
+  buf:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: bufbuild/buf-action@v1
         with:
           token: ${{ secrets.BUF_TOKEN }}

--- a/examples/skip-on-labels/buf-ci.yaml
+++ b/examples/skip-on-labels/buf-ci.yaml
@@ -7,11 +7,12 @@ on:
   delete:
 permissions:
   contents: read
+  pull-requests: write
 jobs:
-  buf:      
+  buf:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: bufbuild/buf-action@v1
         with:
           token: ${{ secrets.BUF_TOKEN }}

--- a/examples/validate-push/buf-ci.yaml
+++ b/examples/validate-push/buf-ci.yaml
@@ -6,10 +6,10 @@ on:
 permissions:
   contents: read
 jobs:
-  buf:      
+  buf:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: bufbuild/buf-action@v1
         with:
           # The token paramater is required to authenticate with the Buf Schema Registry.

--- a/examples/version-env/buf-ci.yaml
+++ b/examples/version-env/buf-ci.yaml
@@ -5,12 +5,12 @@ on:
 permissions:
   contents: read
 env:
-  BUF_VERSION: "1.32.0"
+  BUF_VERSION: "1.72.0"
 jobs:
-  buf:      
+  buf:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: bufbuild/buf-action@v1
         with:
           setup_only: true

--- a/examples/version-input/buf-ci.yaml
+++ b/examples/version-input/buf-ci.yaml
@@ -8,9 +8,9 @@ jobs:
   buf:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: bufbuild/buf-action@v1
         with:
           setup_only: true
-          version: 1.50.1
+          version: 1.72.0
       - run: buf version

--- a/examples/version-latest/buf-ci.yaml
+++ b/examples/version-latest/buf-ci.yaml
@@ -5,10 +5,10 @@ on:
 permissions:
   contents: read
 jobs:
-  buf:      
+  buf:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: bufbuild/buf-action@v1
         with:
           setup_only: true


### PR DESCRIPTION
Update the GHA examples to reflect changes made in the action and update to the latest version of external actions.

Enable GHA updates in dependabot.